### PR TITLE
helper: change probes to http get

### DIFF
--- a/charts/s1-agent/templates/helper/deployment.yaml
+++ b/charts/s1-agent/templates/helper/deployment.yaml
@@ -41,19 +41,16 @@ spec:
               protocol: TCP
         {{- if .Values.helper.probe }}
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /health
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 5
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: /health
               port: 8080
             initialDelaySeconds: 30
-            periodSeconds: 5
-          startupProbe:
-            tcpSocket:
-              port: 80
-            failureThreshold: 30
             periodSeconds: 5
         {{- end }}
           resources:


### PR DESCRIPTION
1. Liveness and readiness probes were changed to send http get health check requests on '/health' path
   instead of tcp.

2. Startup probe was removed because it is not supported by old k8s versions.