### PR TITLE
Allow the optional use of a full image tag

### DIFF
--- a/charts/s1-agent/templates/agent/daemonset.yaml
+++ b/charts/s1-agent/templates/agent/daemonset.yaml
@@ -30,7 +30,11 @@ spec:
       serviceAccountName: {{ include "sentinelone.serviceAccountName" . }}
       containers:
       - name: agent
+{{- if .Values.configuration.image.agent }}
+        image: "{{ .Values.configuration.image.agent }}"
+{{- else }}
         image: "{{ default "docker.pkg.github.com/s1-agents/cwpp_agent/s1agent" .Values.configuration.repositories.agent }}:{{ required "Must set the appropriate tag for image pullling" .Values.configuration.tag.agent }}"
+{{- end }}
 {{- if .Values.configuration.custom_ca }}
         # run update-ca-certificates before starting agent in case a custom certificate is used
         command: ["/bin/sh", "-c", "sudo update-ca-certificates && /home/user/deployment.sh"]

--- a/charts/s1-agent/templates/helper/deployment.yaml
+++ b/charts/s1-agent/templates/helper/deployment.yaml
@@ -26,7 +26,11 @@ spec:
         - name: helper
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+{{- if .Values.configuration.image.helper }}
+          image: "{{ .Values.configuration.image.helper }}"
+{{- else }}
           image: "{{ default "docker.pkg.github.com/s1-agents/cwpp_agent/s1helper" .Values.configuration.repositories.helper }}:{{ default .Values.configuration.tag.agent .Values.configuration.tag.helper }}"
+{{- end }}
           imagePullPolicy: {{ default "IfNotPresent" .Values.configuration.imagePullPolicy }}
           env:
 {{- if .Values.configuration.cluster.name }}

--- a/charts/s1-agent/values.yaml
+++ b/charts/s1-agent/values.yaml
@@ -10,6 +10,9 @@ configuration:
   tag:
     agent: "ea2-21.7.2" # IF you want to use a different tag for the agent (only do so if advised by support), please replace this with the relevant tag for the agent image
     helper: "ea2-21.7.2" # IF you want to use a different tag for the helper (only do so if advised by support), please replace this with the relevant tag for the helper image
+  image:
+    agent: "" # Leave empty to use repositories and tags above, or enter a full image with repo:tag to override the above values
+    helper: "" # Leave empty to use repositories and tags above, or enter a full image with repo:tag to override the above values
   proxy: "" # specify a proxy server (in URL format), if needed
   dv_proxy: "" # specify a proxy server for Deep-Visibility (in URL format), if needed
   env:


### PR DESCRIPTION
Separating the image repository and tag is sometimes undesirable, therefore I would like the ability to specify a full image tag which includes the repository and tag in the same string. This PR allows that but does not change the current default behavior of using the separate repo and tag, so it should be safe to merge.

The code and code comments should explain everything and make clear what the intention is and how it works.