### PR TITLE
[LNX-4890] s1-agent: agent: fix dns access from agent

### DIFF
--- a/charts/s1-agent/templates/agent/daemonset.yaml
+++ b/charts/s1-agent/templates/agent/daemonset.yaml
@@ -24,6 +24,7 @@ spec:
 {{- end }}
       hostPID: true
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000


### PR DESCRIPTION
The agents couldn't access the helper using dns 's1' after setting
hostNetwork to true. To fix that 'dnsPolicy: ClusterFirstWithHostNet'
setting was added as well.
Refer to https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy.