### PR TITLE
agent: use dnsPolicy: ClusterFirstWithHostNet

### DIFF
--- a/charts/s1-agent/templates/agent/daemonset.yaml
+++ b/charts/s1-agent/templates/agent/daemonset.yaml
@@ -24,6 +24,7 @@ spec:
 {{- end }}
       hostPID: true
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000


### PR DESCRIPTION
As can be seen here:
https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy