### PR TITLE
[LNX-4990] charts: fix helm line errors

### DIFF
--- a/charts/s1-agent/Chart.yaml
+++ b/charts/s1-agent/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "21.10.2"
 description: Early Availability version of the SentinelOne Kubernetes Agent
 name: s1-agent

--- a/charts/s1-agent/values.yaml
+++ b/charts/s1-agent/values.yaml
@@ -36,9 +36,9 @@ configuration:
 secrets:
   imagePullSecret: "" # you need to specify the name of the image pull secret (created outside this chart)
   site_key:
-    create: true # set create to "false" if you want to use a secret created outside this helm chart, or for agent offline mode.
+    create: false # set create to "false" if you want to use a secret created outside this helm chart, or for agent offline mode.
     name: ""  # set secret name if you set 'create' to false, otherwise the agents will work in offline mode.
-    value: "" # set site token if you set 'create' to true.
+    value: "" # set 'create' to true if you set site token.
 
 # Most users will not want to make changes below this line.
 


### PR DESCRIPTION
'helm lint' command prompted 2 errors:
1. Charts api version v1 doesn't support 'application' type,
   v2 does, so changing to v2 fixed the issue.
2. When secret create is set to true, a site key must be set as well,
   so defaults create=true, site_key="" are invalid. Changing
   'create' value to false fixed the issue. It should be set to true
   only when setting a site key.