### PR TITLE
[CWS-676] add SYS_MODULE as a required capability

### DIFF
--- a/charts/s1-agent/templates/agent/daemonset.yaml
+++ b/charts/s1-agent/templates/agent/daemonset.yaml
@@ -99,6 +99,7 @@ spec:
               - SYS_RESOURCE
               - SYSLOG
               - SYS_CHROOT
+              - SYS_MODULE
       volumes:
 {{- if .Values.configuration.custom_ca }}
         - name: ca-certs


### PR DESCRIPTION
The agent needs this capability to load the system kernel modules
that are responsible for iptables network filtering (ipv4 and ipv6).