### PR TITLE
charts: configurable priorityClassName

### DIFF
--- a/charts/s1-agent/templates/agent/daemonset.yaml
+++ b/charts/s1-agent/templates/agent/daemonset.yaml
@@ -115,6 +115,9 @@ spec:
     {{- with .Values.agent.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if .Values.agent.priorityClassName }}
+      priorityClassName: {{ .Values.agent.priorityClassName }}
+    {{- end }}
     {{- with .Values.agent.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/s1-agent/templates/helper/deployment.yaml
+++ b/charts/s1-agent/templates/helper/deployment.yaml
@@ -60,6 +60,9 @@ spec:
     {{- with .Values.helper.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if .Values.helper.priorityClassName }}
+      priorityClassName: {{ .Values.helper.priorityClassName }}
+    {{- end }}
     {{- with .Values.helper.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/s1-agent/values.yaml
+++ b/charts/s1-agent/values.yaml
@@ -70,6 +70,7 @@ helper:
             values:
             - arm64
   probe: false
+  priorityClassName: ""
   resources:
     limits:
       cpu: 900m
@@ -104,6 +105,7 @@ agent:
             operator: NotIn
             values:
             - arm64
+  priorityClassName: ""
   resources:
     limits:
       cpu: 900m


### PR DESCRIPTION
fixes: #42

Allow setting a priorityClassName for either or both agent and helper