### PR TITLE
platform: fix: add SYS_MODULE to scc for OpenShift

### DIFF
--- a/charts/s1-agent/templates/platforms/openshift/openshift.yaml
+++ b/charts/s1-agent/templates/platforms/openshift/openshift.yaml
@@ -24,6 +24,7 @@ allowedCapabilities:
   - SETGID
   - SETUID
   - SYS_ADMIN
+  - SYS_MODULE
   - SYS_PTRACE
   - SYS_RAWIO
   - SYS_RESOURCE


### PR DESCRIPTION
fixes #44

The recently added SYS_MODULE capability should also be explicitely
allowed in the SCC for OpenShift