### PR TITLE
[CWS-930] apparmor: add default profile

### DIFF
--- a/profiles/s1_demo_apparmor_profile
+++ b/profiles/s1_demo_apparmor_profile
@@ -1,0 +1,25 @@
+profile s1_demo_profile flags=(attach_disconnected) {
+  network,
+  capability,
+  file,
+  umount,
+  mount,
+  ptrace,
+  signal (receive) peer=unconfined,
+  signal (send,receive) peer=s1_demo_profile,
+  deny /proc/* w,   # deny write for all files directly in /proc (not in a subdir)
+  # deny write to files not in /proc/<number>/** or /proc/sys/**
+  deny /proc/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,
+  deny /proc/sys/[^k]** w,  # deny /proc/sys except /proc/sys/k* (effectively /proc/sys/kernel)
+  deny /proc/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm* in /proc/sys/kernel/
+  deny /proc/sysrq-trigger rwklx,
+  deny /proc/kcore rwklx,
+  deny /sys/[^f]*/** wklx,
+  deny /sys/f[^s]*/** wklx,
+  deny /sys/fs/[^c]*/** wklx,
+  deny /sys/fs/c[^g]*/** wklx,
+  deny /sys/fs/cg[^r]*/** wklx,
+  deny /sys/firmware/** rwklx,
+  deny /sys/kernel/security/** rwklx,
+}
+


### PR DESCRIPTION
The profile is based on the default apparmor profile with few adjustments
to allow the agent to run