### PR TITLE
[CWS-1709] charts: fix helm lint errors

### DIFF
--- a/charts/s1-agent/Chart.yaml
+++ b/charts/s1-agent/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "22.2.1"
 description: Early Availability version of the SentinelOne Kubernetes Agent
 name: s1-agent

--- a/charts/s1-agent/templates/NOTES.txt
+++ b/charts/s1-agent/templates/NOTES.txt
@@ -16,10 +16,12 @@ Configuration options used to deploy:
   This will be reported as the "Cluster Name" in your console, in the details of every node of this cluster.
 * Platform support enabled for: '{{ .Values.configuration.platform.type }}'
 
-{{- if .Values.secrets.site_key.create }}
-* A site-key secret was CREATED (or overwritten if it already existed).
+{{- if include "site_key.secret.create" . }}
+* A site-key secret named '{{ include "site_key.secret.name" . }}' was CREATED (or overwritten if it already existed).
+{{- else if include "site_key.secret.name" . }}
+* The name of the PRE-EXISTING site-key secret to use is '{{ include "site_key.secret.name" . }}'
 {{- else }}
-* The name of the PRE-EXISTING site-key secret to use is '{{ .Values.secrets.site_key.name }}'
+* Neither a site-key secret name nor a value to create the secret with was provided. The agents will work in OFFLINE mode.
 {{- end }}
 {{- if .Values.configuration.custom_ca }}
 * A custom CA certificate will be loaded into the agent image. These files were loaded. If the list is empty, then you probably did not copy the certificate files to "files/*.pem"
@@ -71,6 +73,6 @@ If the agents do not show up in the console, please check that:
 * If an on-prem console with a certificate signed by a private CA is used, a CA certificate was supplied.
   If you supplied a CA certificate, check that it is stored in the namespace of this chart in your cluster as 'ca-certificate'
 * Agent pods can reach the console via HTTPS
-{{- if not .Values.secrets.site_key.create }}
-* You had opted to use an EXISTING site key. Make sure that in namespace '{{ .Release.Namespace }}', the secret '{{ .Values.secrets.site_key.name }}' ACTUALLY exists, or agents will be unable to register.
+{{- if not (include "site_key.secret.create" .) }}
+* You had opted to use an EXISTING site key. Make sure that in namespace '{{ .Release.Namespace }}', the secret '{{ include "site_key.secret.name" . }}' ACTUALLY exists, or agents will be unable to register.
 {{- end -}}

--- a/charts/s1-agent/templates/_helpers.tpl
+++ b/charts/s1-agent/templates/_helpers.tpl
@@ -147,8 +147,12 @@ Create the name of the service account to use
 {{- end -}}
 {{- end -}}
 
+{{- define "site_key.secret.create" -}}
+{{- empty .Values.secrets.site_key.value | ternary "" "true" }}
+{{- end -}}
+
 {{- define "site_key.secret.name" -}}
-{{- if .Values.secrets.site_key.create }}
+{{- if include "site_key.secret.create" . }}
 {{- include "agent.fullname" . -}}
 {{- else -}}
 {{- .Values.secrets.site_key.name -}}

--- a/charts/s1-agent/templates/common/secrets.yaml
+++ b/charts/s1-agent/templates/common/secrets.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.secrets.site_key.create -}}
+{{- if include "site_key.secret.create" . -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "agent.fullname" . }}
+  name: {{ include "site_key.secret.name" . }} 
   labels: {{- include "sentinelone.agent.labels" . | nindent 4 }}
 type: Opaque
 data:

--- a/charts/s1-agent/values.yaml
+++ b/charts/s1-agent/values.yaml
@@ -39,10 +39,9 @@ configuration:
 
 secrets:
   imagePullSecret: "" # you need to specify the name of the image pull secret (created outside this chart)
-  site_key:
-    create: true # set create to "false" if you want to use a secret created outside this helm chart, or for agent offline mode.
-    name: ""  # set secret name if you set 'create' to false, otherwise the agents will work in offline mode.
-    value: "" # set site token if you set 'create' to true.
+  site_key: # if neither were supplied, the agent will work offline mode
+    value: "" # set site token if you want a secret to be crated with that value.
+    name: ""  # set the name of a pre-existing secret to use
 
 # Most users will not want to make changes below this line.
 


### PR DESCRIPTION
Removed the ability to specify .Values.secrets.site_key.create to
control the creation of the site_key secret. Instead, it is determined
by the presence of .Values.secrets.site_key.value :
if present, create the secret. if not, use the pre-existing secret
supplied in .Values.secrets.site_key.name.
If both are empty, work in offline mode.