### PR TITLE
[CWS-1709] charts: added priorityClassName as a configuration

### DIFF
--- a/charts/s1-agent/templates/NOTES.txt
+++ b/charts/s1-agent/templates/NOTES.txt
@@ -66,6 +66,9 @@ If the pods do not start, please check if:
 * The images can be pulled. This requires that:
   - The image pull secret '{{ .Values.secrets.imagePullSecret }}' exists in the namespace of this chart
   - The registries for Agent and Helper images can be reached
+{{- if or .Values.agent.priorityClassName .Values.helper.priorityClassName }}
+  - The values specified for the priorityClassName fields are valid
+{{- end }}
 
 If the agents do not show up in the console, please check that:
 

--- a/charts/s1-agent/templates/agent/daemonset.yaml
+++ b/charts/s1-agent/templates/agent/daemonset.yaml
@@ -129,6 +129,9 @@ spec:
     {{- with .Values.agent.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if default .Values.helper.priorityClassName .Values.agent.priorityClassName }}
+      priorityClassName: {{ default .Values.helper.priorityClassName .Values.agent.priorityClassName }}
+    {{- end }}
     {{- with .Values.agent.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/s1-agent/templates/helper/deployment.yaml
+++ b/charts/s1-agent/templates/helper/deployment.yaml
@@ -66,6 +66,9 @@ spec:
     {{- with .Values.helper.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if default .Values.agent.priorityClassName .Values.helper.priorityClassName }}
+      priorityClassName: {{ default .Values.agent.priorityClassName .Values.helper.priorityClassName }}
+    {{- end }}
     {{- with .Values.helper.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/s1-agent/values.yaml
+++ b/charts/s1-agent/values.yaml
@@ -58,6 +58,7 @@ securityContext: {}
 helper:
   labels: {}
   nodeSelector: {}
+  priorityClassName: ""
   tolerations: {}
   affinity:
     nodeAffinity:
@@ -87,6 +88,7 @@ helper:
 agent:
   labels: {}
   nodeSelector: {}
+  priorityClassName: ""
   podAnnotations: ""
   apparmorAnnotation: container.apparmor.security.beta.kubernetes.io/agent
   apparmorPolicy: unconfined


### PR DESCRIPTION
Now it is possible to specify priorityClassName for the agent and the
helper pods. If both are specified, each one will use it's own
configuration. If only one specified, it will be used for both.