### PR TITLE
charts: explicitly set default log_level to match values.yaml comments

### DIFF
--- a/charts/s1-agent/templates/agent/daemonset.yaml
+++ b/charts/s1-agent/templates/agent/daemonset.yaml
@@ -68,7 +68,7 @@ spec:
         - name: S1_HEAP_TRIMMING_INTERVAL
           value: "{{ .Values.configuration.env.agent.heap_trimming_interval }}"
         - name: S1_LOG_LEVEL
-          value: "{{ .Values.configuration.env.agent.log_level }}"
+          value: "{{ default "info" .Values.configuration.env.agent.log_level }}"
         - name: S1_POD_UID
           value: "{{ .Values.configuration.env.agent.pod_uid }}"
         - name: S1_POD_GID

--- a/charts/s1-agent/templates/helper/deployment.yaml
+++ b/charts/s1-agent/templates/helper/deployment.yaml
@@ -40,7 +40,7 @@ spec:
           - name: SERVER_PORT
             value: "{{ include "service.target_port" . }}"
           - name: LOG_LEVEL
-            value: {{ .Values.configuration.env.helper.log_level }}
+            value: {{ default "info" .Values.configuration.env.helper.log_level }}
           ports:
             - name: https
               containerPort: {{ include "service.target_port" . }}


### PR DESCRIPTION
**Change Summary**

[charts/s1-agent/values.yaml](https://github.com/Sentinel-One/helm-charts/blob/master/charts/s1-agent/values.yaml#L23) declares that an unset `log_level` will default to `info`.

This proposed change explicitly implements that declaration for both the agent and helper.