### PR TITLE
Feature/improve ca certs

### DIFF
--- a/charts/s1-agent/templates/NOTES.txt
+++ b/charts/s1-agent/templates/NOTES.txt
@@ -24,11 +24,16 @@ Configuration options used to deploy:
 * Neither a site-key secret name nor a value to create the secret with was provided. The agents will work in OFFLINE mode.
 {{- end }}
 {{- if .Values.configuration.custom_ca }}
-* A custom CA certificate will be loaded into the agent image. These files were loaded. If the list is empty, then you probably did not copy the certificate files to "files/*.pem"
-{{- range $path, $_ := .Files.Glob "files/*.pem" }}
-  -> {{ base $path }}
+{{- if .Values.configuration.custom_ca_path }}
+* A custom CA certificate will be loaded into the agent image. These certificates were loaded with "--set-files". If the list is empty, check your arguments.
+{{- else -}}
+* A custom CA certificate will be loaded into the agent image. These files were loaded. If the list is empty, then you probably did not copy the certificate files to "files/*.pem".
+{{- end -}}
+{{- $certs := fromYaml (include "agent.certificate_names" .) }}
+{{- range $cert := $certs.certificates }}
+  -> {{ base $cert }}
 {{- end }}
-{{- end }}
+{{- end -}}
 {{- if .Values.configuration.proxy }}
 * A proxy will be used between AGENTS and MANAGEMENT: '{{ .Values.configuration.proxy }}'
 {{- else }}

--- a/charts/s1-agent/templates/NOTES.txt
+++ b/charts/s1-agent/templates/NOTES.txt
@@ -25,15 +25,16 @@ Configuration options used to deploy:
 {{- end }}
 {{- if .Values.configuration.custom_ca }}
 {{- if .Values.configuration.custom_ca_path }}
+data: |-
 * A custom CA certificate will be loaded into the agent image. These certificates were loaded with "--set-files". If the list is empty, check your arguments.
 {{- else -}}
 * A custom CA certificate will be loaded into the agent image. These files were loaded. If the list is empty, then you probably did not copy the certificate files to "files/*.pem".
 {{- end -}}
-{{- $certs := fromYaml (include "agent.certificate_names" .) }}
-{{- range $cert := $certs.certificates }}
-  -> {{ base $cert }}
+{{- $agentCerts := fromYaml (include "agent.certificates" .) -}}
+{{- range $cert := $agentCerts.certificates }}
+  -> {{ $cert.name }}
 {{- end }}
-{{- end -}}
+{{- end }}
 {{- if .Values.configuration.proxy }}
 * A proxy will be used between AGENTS and MANAGEMENT: '{{ .Values.configuration.proxy }}'
 {{- else }}

--- a/charts/s1-agent/templates/_helpers.tpl
+++ b/charts/s1-agent/templates/_helpers.tpl
@@ -216,138 +216,26 @@ Generate certificates for helper secret
 {{- end -}}
 
 {{/*
-Get certificates for custom ca
-*/}}
-{{- define "custom_certs1" -}}
-{{- $ca_paths := .Values.configuration.custom_ca_path -}}
-{{- range $index, $path := $ca_paths -}}
-{{- printf "cert_%s.pem: %s" $index ($path |b64enc) | toYaml | nindent 2 -}}
-{{- end }}
-{{- end }}
-
-
-{{/*
   Helper template to loop through Values.configuration.custom_ca_path and create a list of certificates with their names and data.
-  */}}
-{{- define "certificates_yaml" -}}
-{{ print "certificates:" | nindent 2 }}
-{{- range $index, $path := .Values.configuration.custom_ca_path }}
-{{- $name := print "cert_" $index ".pem" -}}
-  {{ printf "- %s: %s" $name ($path | b64enc) | nindent 4 -}}
-  {{/*
-  {{ printf "- %s: %s" $name ($path | b64enc) }}
-  {{ printf "- %s: |-" $name | nindent 2}}
-  {{ $path | nindent 4}}
-  */}}
-{{- end -}}
-{{- end }}
-
-
-{{/*
+*/}}
 {{- define "certificates" -}}
-{{- $certificates := .Values.configuration.custom_ca_path -}}
-{{- $certificatesMap := dict -}}
-{{- range $index, $certificatePath := $certificates }}
-{{- $certificatesMap.Set (toString $index) (dict "name" $index "path" $certificatePath) }}
-{{- end }}
-{{- $certificatesMap }}
-{{- end }}
-*/}}
-
-{{/*
-	Helper function to create a map of certificate data from a list of file paths
-	*/}}
-{{/*
-	{{- define "certificates" -}}
-	  {{- $certificatesMap := dict -}}
-	  {{- range $index, $path := .Values.configuration.custom_ca_path }}
-		{{- $certificatesMap = $certificatesMap | merge (dict (printf "cert-%d" $index) (dict "name" $index "path" $path)) }}
-	  {{- end }}
-	  {{- $certificatesMap -}}
-	{{- end }}
-*/}}
-
-{{/*
-	Helper template to loop through Values.configuration.custom_ca_path and create a list of certificates with their names and data.
-*/}}
-
-{{- define "certificates3" -}}
-{{- $certificatesMap := dict -}}
-{{- range $index, $path := .Values.configuration.custom_ca_path }}
-{{- $name := print "cert_" $index ".pem" -}}
-{{- $data := $path | b64enc -}}
-{{- $certificatesMap = $certificatesMap | merge (dict "name" $name "data" $data) -}}
-{{- end }}
-{{- $certificatesMap -}}
-{{- end }}
-
-{{- define "ca-certs" }}
-{{- $ca_list := list }}
-{{- $ca_paths := .Values.configuration.custom_ca_path }}
-{{- range $index, $path := $ca_paths }}
-{{- $ca_list := append $ca_list (dict "certName" $index "data" (print $path | b64enc)) -}}
-{{/*}}
-{{- $name := printf "cert_%d" $index }}
-{{- $data := $path }}
-{{- $ca_list = append $ca_list (dict "name" $name "data" $data) }}
-{{- end }}
-{{- end }}
-{{- $ca_list }} */}}
-{{- end}}
-{{- $ca_list -}}
-{{- end }}
-
-{{/*
-  Get certificates for custom ca
-*/}}
-{{- define "custom_certs" -}}
 {{- if .Values.configuration.custom_ca }}
 {{- if .Values.configuration.custom_ca_path -}}
-{{- range $secretName, $secret := .Values.configuration.custom_ca_path -}}
-{{- $certFileName := "" -}}
-{{- if gt (len (toString $secretName)) 2 -}}
-{{- $certFileName = (print $secretName ".pem") -}}
-{{- else -}}
-{{- $certFileName = (print "custom_cert_" (toString $secretName) ".pem") -}}
+{{- $ca_paths := .Values.configuration.custom_ca_path -}}
+{{- range $index, $path := $ca_paths -}}
+{{- $name := print $index -}}
+{{- if not (hasSuffix ".pem" $name) -}}
+{{- $name = print "custom_ca_" $name ".pem" -}}
 {{- end -}}
-- name: {{$certFileName}}
-  value: {{ $secret | b64enc}}
-{{- end -}}
+  {{ $name }}: |-
+    {{ $path | b64enc }}
+{{ end }}
 {{- else -}}
 {{- range $path, $_ := .Files.Glob "files/*.pem" -}}
-- name: {{base $path}}
-  value: {{ $.Files.Get $path | b64enc}}
+  {{ base $path }}: |-
+    {{ $.Files.Get $path | b64enc }}
 {{- end -}}
 {{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{- define "certificates" -}}
-{{- if .Values.configuration.custom_ca }}
-{{- $ca_paths := .Values.configuration.custom_ca_path -}}
-{{- range $index, $path := $ca_paths -}}
-{{- $name := print $index -}}
-{{- if not (hasSuffix $name ".pem") -}}
-  {{- $name = print "custom_ca_" $name ".pem" -}}
-{{- end -}}
-  {{ $name }}: |-
-    {{ $path | b64enc }}
-{{ end }}
-{{- end -}}
-{{- end -}}
-
-
-{{- define "certificates_names" -}}
-{{- if .Values.configuration.custom_ca }}
-{{- $ca_paths := .Values.configuration.custom_ca_path -}}
-{{- range $index, $path := $ca_paths -}}
-{{- $name := print $index -}}
-{{- if not (hasSuffix $name ".pem") -}}
-  {{- $name = print "custom_ca_" $name ".pem" -}}
-{{- end -}}
-  {{ $name }}: |-
-    {{ $path | b64enc }}
-{{ end }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/s1-agent/templates/_helpers.tpl
+++ b/charts/s1-agent/templates/_helpers.tpl
@@ -218,7 +218,7 @@ Generate certificates for helper secret
 {{/*
   Helper template to loop through Values.configuration.custom_ca_path and create a list of certificates with their names and data.
 */}}
-{{- define "certificates" -}}
+{{- define "agent.certificates" -}}
 {{- if .Values.configuration.custom_ca }}
 {{- if .Values.configuration.custom_ca_path -}}
 {{- $ca_paths := .Values.configuration.custom_ca_path -}}
@@ -234,6 +234,26 @@ Generate certificates for helper secret
 {{- range $path, $_ := .Files.Glob "files/*.pem" -}}
   {{ base $path }}: |-
     {{ $.Files.Get $path | b64enc }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "agent.certificate_names" -}}
+{{- if .Values.configuration.custom_ca -}}
+certificates:
+{{- if .Values.configuration.custom_ca_path -}}
+{{- $ca_paths := .Values.configuration.custom_ca_path -}}
+{{- range $index, $path := $ca_paths -}}
+{{- $name := print $index -}}
+{{- if not (hasSuffix ".pem" $name) -}}
+{{- $name = print "custom_ca_" $name ".pem" -}}
+{{- end }}
+- {{ $name }}
+{{- end -}}
+{{- else -}}
+{{- range $path, $_ := .Files.Glob "files/*.pem" -}}
+- {{ base $path }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/s1-agent/templates/_helpers.tpl
+++ b/charts/s1-agent/templates/_helpers.tpl
@@ -219,21 +219,27 @@ Generate certificates for helper secret
   Helper template to loop through Values.configuration.custom_ca_path and create a list of certificates with their names and data.
 */}}
 {{- define "agent.certificates" -}}
-{{- if .Values.configuration.custom_ca }}
+{{- if .Values.configuration.custom_ca -}}
+certificates:
 {{- if .Values.configuration.custom_ca_path -}}
 {{- $ca_paths := .Values.configuration.custom_ca_path -}}
 {{- range $index, $path := $ca_paths -}}
-{{- $name := print $index -}}
-{{- if not (hasSuffix ".pem" $name) -}}
+{{- $name := $index -}}
+{{- if (kindIs "int" $index) -}}
 {{- $name = print "custom_ca_" $name ".pem" -}}
+{{- else -}}
+{{- $name := print $index -}}
 {{- end -}}
-  {{ $name }}: |-
-    {{ $path | b64enc }}
+{{- if not (hasSuffix ".pem" $name) -}}
+{{- $name = print $name ".pem" -}}
+{{- end }}
+- name: {{ $name }}
+  data: {{ $path | b64enc }}
 {{ end }}
 {{- else -}}
-{{- range $path, $_ := .Files.Glob "files/*.pem" -}}
-  {{ base $path }}: |-
-    {{ $.Files.Get $path | b64enc }}
+{{- range $path, $_ := .Files.Glob "files/*.pem" }}
+- name: {{ base $path }}
+  data: {{ $.Files.Get $path | b64enc }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/s1-agent/templates/_helpers.tpl
+++ b/charts/s1-agent/templates/_helpers.tpl
@@ -216,7 +216,8 @@ Generate certificates for helper secret
 {{- end -}}
 
 {{/*
-  Helper template to loop through Values.configuration.custom_ca_path and create a list of certificates with their names and data.
+Collect a list of all custom certificates to be passed to the agent.
+Prefer certificates passed with the --set-file option to .Values.configuration.custom_ca_path, but fall back to checking for certificates in files/*.pem.
 */}}
 {{- define "agent.certificates" -}}
 {{- if .Values.configuration.custom_ca -}}
@@ -240,26 +241,6 @@ certificates:
 {{- range $path, $_ := .Files.Glob "files/*.pem" }}
 - name: {{ base $path }}
   data: {{ $.Files.Get $path | b64enc }}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{- define "agent.certificate_names" -}}
-{{- if .Values.configuration.custom_ca -}}
-certificates:
-{{- if .Values.configuration.custom_ca_path -}}
-{{- $ca_paths := .Values.configuration.custom_ca_path -}}
-{{- range $index, $path := $ca_paths -}}
-{{- $name := print $index -}}
-{{- if not (hasSuffix ".pem" $name) -}}
-{{- $name = print "custom_ca_" $name ".pem" -}}
-{{- end }}
-- {{ $name }}
-{{- end -}}
-{{- else -}}
-{{- range $path, $_ := .Files.Glob "files/*.pem" -}}
-- {{ base $path }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/s1-agent/templates/agent/ca.certificate.yaml
+++ b/charts/s1-agent/templates/agent/ca.certificate.yaml
@@ -5,6 +5,11 @@ metadata:
   name: {{ include "agent.fullname" . }}-custom-ca
   labels: {{- include "sentinelone.agent.labels" . | nindent 4 }}
 type: Opaque
-data: {{- include "agent.certificates" . | nindent 2 -}}
+{{/*data: {{- include "agent.certificates" . | nindent 2 -}}*/}}
+{{- $agentCerts := fromYaml (include "agent.certificates" .) -}}
+data:
+{{- range $cert := $agentCerts.certificates }}
+  {{- $cert.name | nindent 2 }}: |-
+    {{- $cert.data | nindent 4 }}
+{{ end }}
 {{- end -}}
-

--- a/charts/s1-agent/templates/agent/ca.certificate.yaml
+++ b/charts/s1-agent/templates/agent/ca.certificate.yaml
@@ -5,20 +5,6 @@ metadata:
   name: {{ include "agent.fullname" . }}-custom-ca
   labels: {{- include "sentinelone.agent.labels" . | nindent 4 }}
 type: Opaque
-data:
-{{- if .Values.configuration.custom_ca_path -}}
-{{ range $secretName, $secret := .Values.configuration.custom_ca_path }}
-  {{- if gt (len (toString $secretName)) 2 }}
-  {{print $secretName ".pem" }}: |-
-  {{- else }}
-  {{print "custom_cert_" $secretName ".pem" }}: |-
-  {{- end }}
-    {{ print $secret | b64enc | indent 4 }}
-{{ end }}
-{{- else -}}
-{{ range $path, $_ := .Files.Glob "files/*.pem" }}
-  {{ base $path }}: |-
-    {{ $.Files.Get $path | b64enc | indent 4 }}
-{{ end }}
-{{- end}}
-{{- end }}
+data: {{- include "agent.certificates" . | nindent 2 -}}
+{{- end -}}
+

--- a/charts/s1-agent/templates/agent/ca.certificate.yaml
+++ b/charts/s1-agent/templates/agent/ca.certificate.yaml
@@ -7,10 +7,13 @@ metadata:
 type: Opaque
 data:
 {{- if .Values.configuration.custom_ca_path -}}
-{{ range $index, $content := .Values.configuration.custom_ca_path }}
-  {{- print "custom_cert_" $index }}: |-
-    {{ print $content | b64enc | indent 4 }}
-
+{{ range $secretName, $secret := .Values.configuration.custom_ca_path }}
+  {{- if gt (len (toString $secretName)) 2 }}
+  {{print $secretName ".pem" }}: |-
+  {{- else }}
+  {{print "custom_cert_" $secretName ".pem" }}: |-
+  {{- end }}
+    {{ print $secret | b64enc | indent 4 }}
 {{ end }}
 {{- else -}}
 {{ range $path, $_ := .Files.Glob "files/*.pem" }}

--- a/charts/s1-agent/templates/agent/ca.certificate.yaml
+++ b/charts/s1-agent/templates/agent/ca.certificate.yaml
@@ -6,10 +6,16 @@ metadata:
   labels: {{- include "sentinelone.agent.labels" . | nindent 4 }}
 type: Opaque
 data:
+{{- if .Values.configuration.custom_ca_path -}}
+{{ range $index, $content := .Values.configuration.custom_ca_path }}
+  {{- print "custom_cert_" $index }}: |-
+    {{ print $content | b64enc | indent 4 }}
+
+{{ end }}
+{{- else -}}
 {{ range $path, $_ := .Files.Glob "files/*.pem" }}
   {{ base $path }}: |-
     {{ $.Files.Get $path | b64enc | indent 4 }}
-
 {{ end }}
+{{- end}}
 {{- end }}
-

--- a/charts/s1-agent/templates/agent/daemonset.yaml
+++ b/charts/s1-agent/templates/agent/daemonset.yaml
@@ -73,10 +73,11 @@ spec:
               fieldPath: metadata.namespace
         volumeMounts:
 {{- if .Values.configuration.custom_ca }}
-{{- range $path, $_ := .Files.Glob "files/*.pem" }}
+{{- $agentCerts := fromYaml (include "agent.certificates" .) -}}
+{{- range $cert := $agentCerts.certificates }}
           - name: ca-certs
-            mountPath: "/usr/local/share/ca-certificates/{{ base $path }}"
-            subPath: "{{ base $path }}"
+            mountPath: "/usr/local/share/ca-certificates/{{ base $cert.name }}"
+            subPath: "{{ $cert.name }}"
 {{- end }}
 {{- end }}
           - name: debugfs

--- a/charts/s1-agent/values.yaml
+++ b/charts/s1-agent/values.yaml
@@ -33,6 +33,7 @@ configuration:
   # If you are using an on-prem console with an un-trusted CA, you need to provide the CA
   # certificate(s) and intermediaries, if needed, under files/*.pem in PEM format
   custom_ca: false
+  custom_ca_path: []
   imagePullPolicy: "" # defaults to IfNotPresent
   platform:
     type: kubernetes # platform-specific support: defaults to kubernetes. possible values: kubernetes, openshift
@@ -46,7 +47,7 @@ secrets:
   helper_certificate: "" # you need to specify the name of the helper signed certificate secret (created outside this chart)
   site_key: # if neither were supplied, the agent will work offline mode
     value: "" # set site token if you want a secret to be crated with that value.
-    name: ""  # set the name of a pre-existing secret to use
+    name: "" # set the name of a pre-existing secret to use
 
 # Most users will not want to make changes below this line.
 
@@ -86,7 +87,7 @@ helper:
   resources:
     limits:
       cpu: 900m
-      memory: 1945Mi # Almost equals to 1.9Gi but isn't fractional 
+      memory: 1945Mi # Almost equals to 1.9Gi but isn't fractional
     requests:
       cpu: 100m
       memory: 100Mi
@@ -95,7 +96,7 @@ helper:
     create: true
 
 agent:
-  capabilities: 
+  capabilities:
     - DAC_OVERRIDE
     - DAC_READ_SEARCH
     - FOWNER


### PR DESCRIPTION
Improved the workflow when working with on-premises management consoles and eliminated the need to unpack the helm chart, copy certificates into the files folder and then repack the helm chart. Certificates can now be passed in via helm's `--set-file` option. Multiple certificates can be passed in by repeating the option and incrementing the index.
```
--set-file configuration.custom_ca_path[0]=<path to pem> s1 s1-agent-23.2.1.tgz
```
(The original workflow of unpacking the helm chart has been maintained.)