### PR TITLE
[CLS-12201] improve castom ca_certs handling

### DIFF
--- a/charts/s1-agent/templates/NOTES.txt
+++ b/charts/s1-agent/templates/NOTES.txt
@@ -24,9 +24,14 @@ Configuration options used to deploy:
 * Neither a site-key secret name nor a value to create the secret with was provided. The agents will work in OFFLINE mode.
 {{- end }}
 {{- if .Values.configuration.custom_ca }}
-* A custom CA certificate will be loaded into the agent image. These files were loaded. If the list is empty, then you probably did not copy the certificate files to "files/*.pem"
-{{- range $path, $_ := .Files.Glob "files/*.pem" }}
-  -> {{ base $path }}
+{{- if .Values.configuration.custom_ca_path }}
+* A custom CA certificate will be loaded into the agent image. These certificates were loaded with "--set-files". If the list is empty, check your arguments.
+{{- else }}
+* A custom CA certificate will be loaded into the agent image. These files were loaded. If the list is empty, then you probably did not copy the certificate files to "files/*.pem".
+{{- end }}
+{{- $agentCerts := fromYaml (include "agent.certificates" .) -}}
+{{- range $cert := $agentCerts.certificates }}
+  -> {{ $cert.name }}
 {{- end }}
 {{- end }}
 {{- if .Values.configuration.proxy }}

--- a/charts/s1-agent/templates/_helpers.tpl
+++ b/charts/s1-agent/templates/_helpers.tpl
@@ -215,6 +215,28 @@ Generate certificates for helper secret
 {{- end -}}
 {{- end -}}
 
+{{/*
+Collect a list of all custom certificates to be passed to the agent.
+Start with certificates passed with the --set-file option to .Values.configuration.custom_ca_path and continue to check for certificates in files/*.pem.
+*/}}
+{{- define "agent.certificates" -}}
+{{- if .Values.configuration.custom_ca -}}
+certificates:
+{{- range $index, $data := .Values.configuration.custom_ca_path }}
+{{- $name := print $index -}}
+{{- if not (hasSuffix ".pem" $name) -}}
+{{- $name = print $name ".pem" -}}
+{{- end }}
+- name: {{ print $name }}
+  data: {{ $data | b64enc }}
+{{- end -}}
+{{- range $path, $_ := .Files.Glob "files/*.pem" }}
+- name: {{ base $path }}
+  data: {{ $.Files.Get $path | b64enc }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "agent.common_env" -}}
 - name: S1_USE_CUSTOM_CA
   value: "{{ .Values.configuration.custom_ca }}"

--- a/charts/s1-agent/templates/agent/ca.certificate.yaml
+++ b/charts/s1-agent/templates/agent/ca.certificate.yaml
@@ -5,11 +5,9 @@ metadata:
   name: {{ include "agent.fullname" . }}-custom-ca
   labels: {{- include "sentinelone.agent.labels" . | nindent 4 }}
 type: Opaque
+{{- $agentCerts := fromYaml (include "agent.certificates" .) }}
 data:
-{{ range $path, $_ := .Files.Glob "files/*.pem" }}
-  {{ base $path }}: |-
-    {{ $.Files.Get $path | b64enc | indent 4 }}
-
-{{ end }}
-{{- end }}
-
+{{- range $cert := $agentCerts.certificates }}
+  {{- $cert.name | nindent 2 }}: {{ $cert.data }}
+{{- end -}}
+{{- end -}}

--- a/charts/s1-agent/templates/agent/daemonset.yaml
+++ b/charts/s1-agent/templates/agent/daemonset.yaml
@@ -73,10 +73,11 @@ spec:
               fieldPath: metadata.namespace
         volumeMounts:
 {{- if .Values.configuration.custom_ca }}
-{{- range $path, $_ := .Files.Glob "files/*.pem" }}
+{{- $agentCerts := fromYaml (include "agent.certificates" .) -}}
+{{- range $cert := $agentCerts.certificates }}
           - name: ca-certs
-            mountPath: "/usr/local/share/ca-certificates/{{ base $path }}"
-            subPath: "{{ base $path }}"
+            mountPath: "/usr/local/share/ca-certificates/{{ $cert.name }}"
+            subPath: "{{ $cert.name }}"
 {{- end }}
 {{- end }}
           - name: debugfs

--- a/charts/s1-agent/values.yaml
+++ b/charts/s1-agent/values.yaml
@@ -33,6 +33,7 @@ configuration:
   # If you are using an on-prem console with an un-trusted CA, you need to provide the CA
   # certificate(s) and intermediaries, if needed, under files/*.pem in PEM format
   custom_ca: false
+  custom_ca_path:
   imagePullPolicy: "" # defaults to IfNotPresent
   platform:
     type: kubernetes # platform-specific support: defaults to kubernetes. possible values: kubernetes, openshift
@@ -46,7 +47,7 @@ secrets:
   helper_certificate: "" # you need to specify the name of the helper signed certificate secret (created outside this chart)
   site_key: # if neither were supplied, the agent will work offline mode
     value: "" # set site token if you want a secret to be crated with that value.
-    name: ""  # set the name of a pre-existing secret to use
+    name: "" # set the name of a pre-existing secret to use
 
 # Most users will not want to make changes below this line.
 
@@ -86,7 +87,7 @@ helper:
   resources:
     limits:
       cpu: 900m
-      memory: 1945Mi # Almost equals to 1.9Gi but isn't fractional 
+      memory: 1945Mi # Almost equals to 1.9Gi but isn't fractional
     requests:
       cpu: 100m
       memory: 100Mi
@@ -95,7 +96,7 @@ helper:
     create: true
 
 agent:
-  capabilities: 
+  capabilities:
     - DAC_OVERRIDE
     - DAC_READ_SEARCH
     - FOWNER


### PR DESCRIPTION
Initially proposed by @s1-nathangerhart

Improved the workflow when working with on-premises management consoles and eliminated the need to unpack the helm chart, copy certificates into the files folder and then repack the helm chart. Certificates can now be passed in via helm's `--set-file` option. Multiple certificates can be passed in by repeating the option and incrementing the index.
```
--set-file configuration.custom_ca_path[0]=<path to pem> ...
```
(The original workflow of unpacking the helm chart has been maintained.)