### PR TITLE
[CLS-10910] templates: common: mount configMap to injected agent

### DIFF
--- a/charts/s1-agent/templates/common/configmaps.yaml
+++ b/charts/s1-agent/templates/common/configmaps.yaml
@@ -55,4 +55,13 @@ data:
           value: "0"
         - name: S1_HELPER_HOST
           value: {{ include "service.name" . }}.{{ .Release.Namespace }}
+        - name: S1_AGENT_CONFIG_FILE
+          value: "/{{ include "agent.fullname" . }}/config.yaml"
 {{ end }}
+        volumeMounts:
+        - name: {{ include "agent.fullname" . }}
+          mountPath: /{{ include "agent.fullname" . }}
+      volumes:
+        - name: {{ include "agent.fullname" . }}
+          configMap:
+            name: {{ include "agent.fullname" . }}


### PR DESCRIPTION
This commit was supposed to be part of the uninstall PR but was added somehow to the wrong branch.