### PR TITLE
[CLS-10991] all: fix charts in none agent injection mode

### DIFF
--- a/charts/s1-agent/templates/_helpers.tpl
+++ b/charts/s1-agent/templates/_helpers.tpl
@@ -193,7 +193,6 @@ Generate certificates for helper secret
 
 {{- define "helper_token.secret.name" -}}
 {{- if include "helper_token.secret.create" . }}
-{{- include "helper.fullname" . -}}
 {{- ( printf "%s-%s" (include "helper.fullname" .) "token" ) -}}
 {{- else -}}
 {{- .Values.secrets.helper_token -}}
@@ -204,7 +203,7 @@ Generate certificates for helper secret
 Generate server token for helper secret
 */}}
 {{- define "helper.token" -}}
-{{- randAlphaNum 24 | nospace -}}
+{{- randAlphaNum 24 | b64enc | quote -}}
 {{- end -}}
 
 {{- define "service.name" -}}

--- a/charts/s1-agent/templates/common/configmaps.yaml
+++ b/charts/s1-agent/templates/common/configmaps.yaml
@@ -65,7 +65,6 @@ data:
           value: {{ include "service.name" . }}.{{ .Release.Namespace }}
         - name: S1_AGENT_CONFIG_FILE
           value: "/{{ include "agent.fullname" . }}/config.yaml"
-{{ end }}
         volumeMounts:
         - name: {{ include "agent.fullname" . }}
           mountPath: /{{ include "agent.fullname" . }}
@@ -73,3 +72,4 @@ data:
         - name: {{ include "agent.fullname" . }}
           configMap:
             name: {{ include "agent.fullname" . }}
+{{ end }}

--- a/charts/s1-agent/templates/common/secrets.yaml
+++ b/charts/s1-agent/templates/common/secrets.yaml
@@ -23,7 +23,7 @@ metadata:
   labels: {{- include "sentinelone.helper.labels" . | nindent 4 }}
 type: kubernetes.io/tls
 data: {{- include "helper.certificates" . | nindent 2 }}
-{{- end -}}
+{{- end }}
 
 ---
 


### PR DESCRIPTION
1. Encode the output of randAlphaNum because it soemtimes generates null char.
2. fix the helper token secret name.
3. Move the mount section in the config map to the main if condition.