### PR TITLE
[CLS-13369] all: protect helper by agent in kubernetes serverless cluster

### DIFF
--- a/charts/s1-agent/templates/NOTES.txt
+++ b/charts/s1-agent/templates/NOTES.txt
@@ -1,5 +1,5 @@
-{{- if not (mustRegexMatch "^(kubernetes|openshift)$" .Values.configuration.platform.type) -}}
-{{ fail "configuration.platform.type must be one of: kubernetes, openshift" }}
+{{- if not (mustRegexMatch "^(kubernetes|openshift|serverless)$" .Values.configuration.platform.type) -}}
+{{ fail "configuration.platform.type must be one of: kubernetes, openshift, serverless" }}
 {{- end -}}
 {{- if not (mustRegexMatch "^(info|error|warning|debug|trace|)$" .Values.configuration.env.helper.log_level) -}}
 {{ fail "configuration.env.helper.log_level must be one of: info, error, warning, debug, trace [or empty to default to 'info']" }}

--- a/charts/s1-agent/templates/agent/daemonset.yaml
+++ b/charts/s1-agent/templates/agent/daemonset.yaml
@@ -1,3 +1,4 @@
+{{ if eq (include "serverlessOnlyMode" .) "false" }}
 apiVersion: {{ template "daemonset.apiVersion" . }}
 kind: DaemonSet
 metadata:
@@ -48,16 +49,6 @@ spec:
 {{- end }}
         - name: S1_AGENT_TYPE
           value: "k8s"
-        - name: S1_HELPER_CRT
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "helper.secret.name" . }}
-              key: tls.crt
-        - name: S1_HELPER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "helper_token.secret.name" . }}
-              key: server-token
         - name: S1_HELPER_HOST
           value: {{ include "service.name" . }}
         - name: S1_AGENT_HOST_MOUNT_PATH
@@ -68,14 +59,6 @@ spec:
           value: "{{ .Values.configuration.env.agent.pod_uid }}"
         - name: S1_POD_GID
           value: "{{ .Values.configuration.env.agent.pod_gid }}"
-        - name: S1_POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: S1_POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         volumeMounts:
 {{- if .Values.configuration.custom_ca }}
 {{- $agentCerts := fromYaml (include "agent.certificates" .) -}}
@@ -124,3 +107,4 @@ spec:
     {{- with .Values.agent.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
     {{- end }}
+{{ end }}

--- a/charts/s1-agent/templates/common/configmaps.yaml
+++ b/charts/s1-agent/templates/common/configmaps.yaml
@@ -14,64 +14,16 @@ data:
   {{- end }}
       shareProcessNamespace: true
       containers:
-      - name: agent
-        image: "{{ include "agent.full_url" . }}"
-        imagePullPolicy: {{ default "IfNotPresent" .Values.configuration.imagePullPolicy }}
-        securityContext:
-          runAsUser: 0
-          runAsGroup: 0
-          capabilities:
-            add:
-              - AUDIT_WRITE
-              - DAC_OVERRIDE
-              - FOWNER
-              - KILL
-              - NET_RAW
-              - SETGID
-              - SETUID
-              - SYS_CHROOT
-        resources:
-{{ toYaml .Values.agentInjection.resources | indent 10 }}
-        env:
-{{- include "agent.common_env" . | nindent 8 }}
-{{- if include "site_key.secret.name" . }}
-        - name: SITE_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "site_key.secret.name" . }}
-              key: site-key
-{{- end }}
-        - name: S1_HELPER_CRT
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "helper.secret.name" . }}
-              key: tls.crt
-{{- if include "helper.secret.create" . }}
-              optional: true
-{{- end }}
-        - name: S1_HELPER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "helper_token.secret.name" . }}
-              key: helper.token
-{{- if include "helper_token.secret.create" . }}
-              optional: true
-{{- end }}
-        - name: S1_AGENT_TYPE
-          value: "k8s_serverless"
-        - name: S1_POD_UID
-          value: "0"
-        - name: S1_POD_GID
-          value: "0"
-        - name: S1_HELPER_HOST
-          value: {{ include "service.name" . }}.{{ .Release.Namespace }}
-        - name: S1_AGENT_CONFIG_FILE
-          value: "/{{ include "agent.fullname" . }}/config.yaml"
-        volumeMounts:
-        - name: {{ include "agent.fullname" . }}
-          mountPath: /{{ include "agent.fullname" . }}
+        {{- include "serverlessAgentContainer" . | nindent 8 }}
+          - name: S1_HELPER_HOST
+            value: {{ include "service.name" . }}.{{ .Release.Namespace }}
+          - name: S1_AGENT_CONFIG_FILE
+            value: "/{{ include "agent.fullname" . }}/config.yaml"
+          volumeMounts:
+          - name: {{ include "agent.fullname" . }}
+            mountPath: /{{ include "agent.fullname" . }}
       volumes:
-        - name: {{ include "agent.fullname" . }}
-          configMap:
-            name: {{ include "agent.fullname" . }}
+      - name: {{ include "agent.fullname" . }}
+        configMap:
+          name: {{ include "agent.fullname" . }}
 {{ end }}

--- a/charts/s1-agent/templates/helper/deployment.yaml
+++ b/charts/s1-agent/templates/helper/deployment.yaml
@@ -19,13 +19,10 @@ spec:
         - name: {{ .Values.secrets.imagePullSecret }}
 {{- end }}
       serviceAccountName: {{ include "sentinelone.serviceAccountName" . }}
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
       containers:
         - name: helper
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml .Values.helper.securityContext | nindent 12 }}
           image: "{{ include "helper.full_url" . }}"
           imagePullPolicy: {{ default "IfNotPresent" .Values.configuration.imagePullPolicy }}
           env:
@@ -91,6 +88,12 @@ spec:
           volumeMounts:
           - name: agent-injection-config
             mountPath: /s1-helper/agent-injection
+    {{- if eq (include "serverlessOnlyMode" .) "true" }}
+        {{- include "serverlessAgentContainer" . | nindent 8 }}
+          - name: S1_HELPER_HOST
+            value: {{ include "service.name" . }}
+      shareProcessNamespace: true
+    {{- end }}
       volumes:
         - name: agent-injection-config
           configMap:

--- a/charts/s1-agent/templates/hooks/mutatingwebhookconfiguration.yaml
+++ b/charts/s1-agent/templates/hooks/mutatingwebhookconfiguration.yaml
@@ -55,8 +55,6 @@ webhooks:
     resources:
     - pods
     scope: '*'
-  {{- with .Values.agentInjection.selector }}
-    {{- toYaml . | nindent 2 }}
-  {{- end }}
+{{- toYaml .Values.agentInjection.selector | nindent 2 }}
   sideEffects: None
 {{ end }}

--- a/charts/s1-agent/templates/hooks/pre-delete-hook.yaml
+++ b/charts/s1-agent/templates/hooks/pre-delete-hook.yaml
@@ -1,7 +1,8 @@
+{{ if eq (include "serverlessOnlyMode" .) "false" }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ .Release.Name }}-uninstall-agent-job"
+  name: {{ include "agentUninstallJob.name" . }}
   labels:
 {{ include "sentinelone.helper.labels" . | nindent 4 }}
   annotations:
@@ -13,7 +14,7 @@ spec:
     metadata:
       labels:
         {{- include "sentinelone.helper.labels" . | nindent 8 }}
-      name: uninstall-agent
+      name: {{ include "agentUninstallJob.name" . }}
     spec:
 {{- if .Values.secrets.imagePullSecret }}
       imagePullSecrets:
@@ -22,7 +23,7 @@ spec:
       restartPolicy: Never
       serviceAccountName: {{ include "sentinelone.serviceAccountName" . }}
       containers:
-        - name: uninstall-agent
+        - name: {{ include "agentUninstallJob.name" . }}
           image: "{{ include "helper.full_url" . }}"
           command: [ "/bin/bash", "-c" ]
           args:
@@ -46,3 +47,4 @@ spec:
                 sleep 1;
               done;
               echo "Done";
+{{ end }}

--- a/charts/s1-agent/values.yaml
+++ b/charts/s1-agent/values.yaml
@@ -36,7 +36,9 @@ configuration:
   custom_ca_path:
   imagePullPolicy: "" # defaults to IfNotPresent
   platform:
-    type: kubernetes # platform-specific support: defaults to kubernetes. possible values: kubernetes, openshift
+    type: kubernetes # platform-specific support: defaults to kubernetes. possible values: kubernetes, openshift and
+                     # serverless for kubernetes cluster without nodes (currently Fargate only). For serverless
+                     # cluster with nodes as well, use kubernetes type.
     # optional settings, used with OpenShift only:
     openshift:
       scc:
@@ -58,9 +60,6 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: sentinelone
-
-# Optional additional values for the helper security context. Not typically needed.
-securityContext: {}
 
 agentInjection:
   selector:
@@ -92,6 +91,10 @@ helper:
             values:
             - linux
   probe: false
+  # Default values for the helper security context
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
   resources:
     limits:
       cpu: 900m


### PR DESCRIPTION
1. Move securityContext in values.yaml to helper container level to allow different settings for agent container running in the same pod.
2. Add 'serverless' type for serverless clusters without nodes, currently Fargate cluster only is supported. Fargate cluster with nodes should use kubernetes type. If this type is not set, the charts will lookup for nodes and will refer to the cluster as serverless if nodes were not found.
3. Don't run agent uninstall job in serverless clusters.
4. Run agent container alongside helper container in serverless clusters.
5. Move S1_POD_NAME and S1_POD_NAMESPACE to common environment variables.