### PR TITLE
[CLS-13369] all: fix injected agent uninstall in severless mode

### DIFF
--- a/charts/s1-agent/templates/_helpers.tpl
+++ b/charts/s1-agent/templates/_helpers.tpl
@@ -369,3 +369,8 @@ certificates:
     value: "0"
 {{- end -}}
 
+{{- define "helper.rbac.annotations" -}}
+{{- if and .Values.configuration.env.injection.enabled (eq (include "serverlessOnlyMode" .) "true") }}
+"helm.sh/resource-policy": keep
+{{- end -}}
+{{- end -}}

--- a/charts/s1-agent/templates/agent/daemonset.yaml
+++ b/charts/s1-agent/templates/agent/daemonset.yaml
@@ -1,4 +1,4 @@
-{{ if eq (include "serverlessOnlyMode" .) "false" }}
+{{ if or (not .Values.configuration.env.injection.enabled) (eq (include "serverlessOnlyMode" .) "false") }}
 apiVersion: {{ template "daemonset.apiVersion" . }}
 kind: DaemonSet
 metadata:

--- a/charts/s1-agent/templates/cluster/cluster-role-bindings.yaml
+++ b/charts/s1-agent/templates/cluster/cluster-role-bindings.yaml
@@ -4,6 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "helper.fullname" . }}
   labels: {{- include "sentinelone.agent.labels" . | nindent 4 }}
+  annotations: {{- include "helper.rbac.annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/s1-agent/templates/cluster/cluster-role.yaml
+++ b/charts/s1-agent/templates/cluster/cluster-role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: {{ include "helper.fullname" . }}
   labels: {{- include "sentinelone.agent.labels" . | nindent 4 }}
+  annotations: {{- include "helper.rbac.annotations" . | nindent 4 }}
 rules:
 - apiGroups: [""]
   resources: ["nodes", "pods", "namespaces", "replicationcontrollers"]

--- a/charts/s1-agent/templates/hooks/pre-delete-hook.yaml
+++ b/charts/s1-agent/templates/hooks/pre-delete-hook.yaml
@@ -1,4 +1,4 @@
-{{ if eq (include "serverlessOnlyMode" .) "false" }}
+{{ if or (not .Values.configuration.env.injection.enabled) (eq (include "serverlessOnlyMode" .) "false") }}
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
Helper, running on Fargate pod, creates secrets and configmaps in each namespace which has injected agents. On uninstall, helm for some reason deletes the cluster role and bindings before the helper shuts down, removes the secrets and updates the configmap. Maybe it takes a while for the helper to shutdown on Fargate and in the meanwhile helm removes the rbac so the helper fails to update the configmap with uninstall status. Therfore, we added annotation to the rbac for keeping them.