### PR TITLE
[CLS-28146] templates: make changes in the agent mount paths

### DIFF
--- a/charts/s1-agent/templates/NOTES.txt
+++ b/charts/s1-agent/templates/NOTES.txt
@@ -44,6 +44,9 @@ Configuration options used to deploy:
 {{- else }}
 * NO proxy will be used between AGENTS and DEEP-VISIBILITY.
 {{- end }}
+{{- if and .Values.configuration.platform.gke.autopilot .Values.configuration.env.agent.persistent_dir }}
+* Custom persistent directory is unsupported in GKE autopilot and will be overridden by a default path.
+{{- end }}
 * The images will be pulled from:
 {{- $agentTag := .Values.configuration.tag.agent -}}
 {{- $helperTag := default .Values.configuration.tag.agent .Values.configuration.tag.helper -}}

--- a/charts/s1-agent/templates/agent/daemonset.yaml
+++ b/charts/s1-agent/templates/agent/daemonset.yaml
@@ -54,7 +54,7 @@ spec:
         - name: S1_AGENT_HOST_MOUNT_PATH
           value: "{{ default "/host" .Values.configuration.env.agent.host_mount_path }}"
         - name: S1_PERSISTENT_DIR
-          value: "{{ default "/var/lib/sentinelone" .Values.configuration.env.agent.persistent_dir }}"
+          value: "/var/lib/sentinelone"
         - name: S1_POD_UID
           value: "{{ .Values.configuration.env.agent.pod_uid }}"
         - name: S1_POD_GID
@@ -68,13 +68,14 @@ spec:
             subPath: "{{ $cert.name }}"
 {{- end }}
 {{- end }}
-          - name: debugfs
-            mountPath: /sys/kernel/debug/
-          - name: modules
-            mountPath: /lib/modules/
           - name: host
             mountPath: {{ default "/host" .Values.configuration.env.agent.host_mount_path }}
             mountPropagation: HostToContainer
+{{- if .Values.configuration.platform.gke.autopilot }}
+            readOnly: true
+{{- end }}
+          - name: persistence
+            mountPath: "/var/lib/sentinelone"
         securityContext:
 {{- if include "bottlerocketNode" . }}
           seLinuxOptions:
@@ -93,15 +94,16 @@ spec:
           secret:
             secretName: "{{ include "agent.fullname" . }}-custom-ca"
 {{- end }}
-        - name: debugfs
-          hostPath:
-            path: /sys/kernel/debug/
-        - name: modules
-          hostPath:
-            path: /lib/modules/
         - name: host
           hostPath:
             path: /
+        - name: persistence
+          hostPath:
+{{- if .Values.configuration.platform.gke.autopilot }}
+            path: /opt/sentinelone
+{{- else }}
+            path: "{{ default "/opt/sentinelone" .Values.configuration.env.agent.persistent_dir }}"
+{{- end }}
     {{- with .Values.agent.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/s1-agent/values.yaml
+++ b/charts/s1-agent/values.yaml
@@ -18,7 +18,7 @@ configuration:
   env:
     agent:
       host_mount_path: # leave default unless host path is mounted elsewhere in your environment
-      persistent_dir: # path on the node to a directory that will be used for persistent storage (logs, configuration, etc.)
+      persistent_dir: # path on the node to a directory that will be used for persistent storage (logs, configuration, etc. Unsupported in GKE autopilot)
       heap_trimming_enable: # to enable/disable heap trimming, set to 'true'/'false'
       heap_trimming_interval: # heap trimming default interval (s)
       log_level: "" # info, error, warning, debug, trace (defaults to 'info')
@@ -46,7 +46,7 @@ configuration:
       scc:
         create: true # enable only if you are using OpenShift; this enables creation of a SecurityContextConstraint required to run on OpenShift
     gke:
-      autopilot: false # enable if you are using gke autopilot.
+      autopilot: false # enable if you are using GKE autopilot.
 
 secrets:
   imagePullSecret: "" # you need to specify the name of the image pull secret (created outside this chart)


### PR DESCRIPTION
1. Remove lib/modules and sys/kernel/debug mounts, it is done by the agent code.
2. Set read only host path in gke autopilot.
3. Add persistence mount for persistent dir which is separated from the host mount.