### PR TITLE
[CLS-32377] Pass gk3 indication to the agent

### DIFF
--- a/charts/s1-agent/templates/agent/daemonset.yaml
+++ b/charts/s1-agent/templates/agent/daemonset.yaml
@@ -48,7 +48,7 @@ spec:
               key: site-key
 {{- end }}
         - name: S1_AGENT_TYPE
-          value: "k8s"
+          value: {{ if .Values.configuration.platform.gke.autopilot }}"k8s-gk3"{{- else }}"k8s"{{- end }}
         - name: S1_HELPER_HOST
           value: {{ include "service.name" . }}
         - name: S1_AGENT_HOST_MOUNT_PATH


### PR DESCRIPTION
We want to pass indication to the agent container, in case we are running on a gk3 (gke autopilot) env. For that, we use the existing env var, to be used later on in the deployment script.

Notice it's currently not possible to modify the names of the existing env vars or to create new env vars, due to admission control limitations (Current GKE AutoPilot policy, will be hopefully changed later)

It was tested together with my branch in the agent (gke-autopilot-dev that was rebased on top of )