### PR TITLE
[CLS-37427] values.yaml: add object selector exclusion to agent injection

### DIFF
--- a/charts/s1-agent/values.yaml
+++ b/charts/s1-agent/values.yaml
@@ -70,6 +70,11 @@ agentInjection:
     namespaceSelector:
       matchLabels:
         agent-injection-enabled: "true"
+    objectSelector:
+      matchExpressions:
+        - key: agent-injection-enabled
+          operator: NotIn
+          values: ["false"]
   resources:
     limits:
       cpu: 900m


### PR DESCRIPTION
Change the agent injection selector to allow injection in case of namespaces with label agent-injection-enabled="true" and pods which don't have the label agent-injection-enabled="false". This change allow injection exclusion for specific pods. These settings are configurable.