### PR TITLE
[CLS-36498] Set default ephemeral-storage for gk3 if not defined

### DIFF
--- a/charts/s1-agent/templates/_helpers.tpl
+++ b/charts/s1-agent/templates/_helpers.tpl
@@ -424,9 +424,15 @@ requests:
 {{- define "agentResources" -}}
 limits:
 {{ toYaml .Values.agent.resources.limits | indent 2 }}
+{{- if and .Values.configuration.platform.gke.autopilot (not (index .Values.agent.resources.limits "ephemeral-storage")) }}
+  ephemeral-storage: 1Gi
+{{- end }}
 requests:
 {{- if .Values.configuration.platform.gke.autopilot }}
 {{ toYaml .Values.agent.resources.limits | indent 2 }}
+{{- if not (index .Values.agent.resources.requests "ephemeral-storage") }}
+  ephemeral-storage: 1Gi
+{{- end }}
 {{- else }}
 {{ toYaml .Values.agent.resources.requests | indent 2 }}
 {{- end -}}


### PR DESCRIPTION
Intended logic:
- If we are in gke-autopilot and limits for ephemeral-storage is not set - set it to 1Gi
- If we are in gke-autopilot and requests for ephemeral-storage is not set - set it to 1Gi
- If we are NOT in gke-autopilot - do nothing (or use user's defined)

When running
`helm install s1 --namespace=sentinelone --set secrets.imagePullSecret=art-ha-secret --set configuration.repositories.helper=artifactory.eng.sentinelone.tech/docker-dev/cws-agents/master/release/s1helper --set configuration.tag.helper=24.1.1.119 --set configuration.env.agent.log_level=debug --set configuration.repositories.agent=artifactory.eng.sentinelone.tech/docker-dev/cws-agents/gke-autopilot-dev/release/s1agent --set configuration.tag.agent=24.2.1.34 --set configuration.env.agent.pod_uid=0 --set configuration.env.agent.pod_gid=0 --set secrets.site_key.value="eyJ1cmwiOiAiaHR0cHM6Ly91c2VhMS1zMS1pbnQtbm0tbGloa3ZtLnNlbnRpbmVsb25lLm5ldCIsICJzaXRlX2tleSI6ICI1MWVjOWYxYmJlMTU1YTUyIn0=" --set configuration.cluster.name=GKE-Autopilot-cp-15 --set configuration.platform.gke.autopilot=true --set agent.resources.limits.ephemeral-storage=2Gi --set agent.resources.requests.ephemeral-storage=2Gi  s1-agent`

It resulted with
```
    Limits:
      cpu:                900m
      ephemeral-storage:  2Gi
      memory:             1945Mi
    Requests:
      cpu:                900m
      ephemeral-storage:  2Gi
      memory:             1945Mi
```

When running
`helm install s1 --namespace=sentinelone --set secrets.imagePullSecret=art-ha-secret --set configuration.repositories.helper=artifactory.eng.sentinelone.tech/docker-dev/cws-agents/master/release/s1helper --set configuration.tag.helper=24.1.1.119 --set configuration.env.agent.log_level=debug --set configuration.repositories.agent=artifactory.eng.sentinelone.tech/docker-dev/cws-agents/gke-autopilot-dev/release/s1agent --set configuration.tag.agent=24.2.1.34 --set configuration.env.agent.pod_uid=0 --set configuration.env.agent.pod_gid=0 --set secrets.site_key.value="eyJ1cmwiOiAiaHR0cHM6Ly91c2VhMS1zMS1pbnQtbm0tbGloa3ZtLnNlbnRpbmVsb25lLm5ldCIsICJzaXRlX2tleSI6ICI1MWVjOWYxYmJlMTU1YTUyIn0=" --set configuration.cluster.name=GKE-Autopilot-cp-15 --set configuration.platform.gke.autopilot=true  s1-agent`

It resulted with
```
    Limits:
      cpu:                900m
      ephemeral-storage:  1Gi
      memory:             1945Mi
    Requests:
      cpu:                900m
      ephemeral-storage:  1Gi
      memory:             1945Mi
```
