### PR TITLE
[CLS-46528] s1-agent: add agent and ebpf disabled mode options

### DIFF
--- a/charts/s1-agent/templates/_helpers.tpl
+++ b/charts/s1-agent/templates/_helpers.tpl
@@ -303,6 +303,8 @@ certificates:
   value: "{{ .Values.configuration.env.agent.helper_healthcheck_interval }}"
 - name: S1_FIPS_ENABLED
   value: "{{ .Values.configuration.env.agent.fips_enabled }}"
+- name: S1_AGENT_ENABLED
+  value: "{{ .Values.configuration.env.agent.enabled }}"
 - name: S1_POD_NAME
   valueFrom:
     fieldRef:

--- a/charts/s1-agent/templates/agent/daemonset.yaml
+++ b/charts/s1-agent/templates/agent/daemonset.yaml
@@ -61,6 +61,8 @@ spec:
           value: "{{ .Values.configuration.env.agent.pod_gid }}"
         - name: S1_AGENT_CONFIG_PATH
           value: "/opt/configmaps/config"
+        - name: S1_EBPF_ENABLED
+          value: "{{ .Values.configuration.env.agent.ebpf_enabled }}"
 {{- if .Values.configuration.platform.gke.autopilot }}
         - name: S1_GKE_AUTOPILOT
           value: "true"

--- a/charts/s1-agent/values.yaml
+++ b/charts/s1-agent/values.yaml
@@ -17,6 +17,7 @@ configuration:
   dv_proxy: "" # specify a proxy server for Deep-Visibility (in URL format), if needed
   env:
     agent:
+      enabled: # to disable the agent, set to 'false'
       host_mount_path: # leave default unless host path is mounted elsewhere in your environment
       persistent_dir: # path on the node to a directory that will be used for persistent storage (logs, configuration, etc. Unsupported in GKE autopilot)
       heap_trimming_enable: # to enable/disable heap trimming, set to 'true'/'false'
@@ -28,6 +29,7 @@ configuration:
       helper_healthcheck_retry: 60 # amount of tries to verify the helper service is running before starting the agent.
       helper_healthcheck_interval: 5 # time to wait between each try. (seconds)
       fips_enabled: # to enable/disable FIPS mode, set to 'true'/'false'
+      ebpf_enabled: # to disable EBPF mode, set to 'false' (Unsupported in EKS Fargate)
     helper:
       log_level: "" # info, error, warning, debug, trace (defaults to 'info')
       client_timeout: # client timeout. (seconds, default=120)


### PR DESCRIPTION
Add helm options
--set configuration.env.agent.enabled=false
--set configuration.env.agent.ebpf_enabled=false
to run the agent in disabled mode or with ebpf in disabled mode