### PR TITLE
[CLS-48357] charts: add  option to deploy only the inventory collector

### DIFF
--- a/charts/s1-agent/templates/_helpers.tpl
+++ b/charts/s1-agent/templates/_helpers.tpl
@@ -462,5 +462,8 @@ requests:
 {{- if $persistent_uuid }}
 {{- $uuid = $persistent_uuid -}}
 {{- end }}
-{{- dict "S1_HELPER_UUID" $uuid "S1_INVENTORY_ENABLED" (printf "%t" .Values.configuration.env.helper.inventory_enabled) | toYaml -}}
+{{- $helperConfig := dict "S1_HELPER_UUID" $uuid -}}
+{{- $_ := set $helperConfig "S1_INVENTORY_ENABLED" (printf "%t" .Values.configuration.env.helper.inventory_enabled) -}}
+{{- $_ := set $helperConfig "S1_INVENTORY_ONLY" (printf "%t" .Values.configuration.inventory_only) -}}
+{{- $helperConfig | toYaml -}}
 {{- end -}}

--- a/charts/s1-agent/templates/agent/daemonset.yaml
+++ b/charts/s1-agent/templates/agent/daemonset.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
 {{- include "sentinelone.agent.labels" . | nindent 8 }}
       annotations:
+        timestamp: {{ now | quote }}
       {{- if .Values.agent.podAnnotations }}
 {{ toYaml .Values.agent.podAnnotations | indent 8 }}
       {{- end }}

--- a/charts/s1-agent/templates/agent/daemonset.yaml
+++ b/charts/s1-agent/templates/agent/daemonset.yaml
@@ -1,4 +1,4 @@
-{{ if or (not .Values.configuration.env.injection.enabled) (eq (include "serverlessOnlyMode" .) "false") }}
+{{ if and (or (not .Values.configuration.env.injection.enabled) (eq (include "serverlessOnlyMode" .) "false")) (not .Values.configuration.inventory_only) }}
 apiVersion: {{ template "daemonset.apiVersion" . }}
 kind: DaemonSet
 metadata:

--- a/charts/s1-agent/templates/helper/deployment.yaml
+++ b/charts/s1-agent/templates/helper/deployment.yaml
@@ -13,8 +13,9 @@ spec:
     metadata:
       labels:
         {{- include "sentinelone.helper.labels" . | nindent 8 }}
-      {{- if .Values.helper.podAnnotations }}
       annotations:
+        timestamp: {{ now | quote }}
+      {{- if .Values.helper.podAnnotations }}
 {{ toYaml .Values.helper.podAnnotations | indent 8 }}
       {{- end }}
     spec:

--- a/charts/s1-agent/values.yaml
+++ b/charts/s1-agent/values.yaml
@@ -54,6 +54,7 @@ configuration:
       autopilot: false # enable if you are using GKE autopilot.
   localConf: # set Agent's initial local.conf configuration.
   overrideConf: # set Agent's initial override.conf configuration.
+  inventory_only: false # enable to deploy only inventory collector
 
 secrets:
   imagePullSecret: "" # you need to specify the name of the image pull secret (created outside this chart)


### PR DESCRIPTION
In case inventory_only is set to true we will deploy only the helper and not the daemonset (s1-agent)