### PR TITLE
[CLS-54448] Re-order volumes alphabetically in Openshift Helm template

### DIFF
--- a/charts/s1-agent/templates/platforms/openshift/openshift.yaml
+++ b/charts/s1-agent/templates/platforms/openshift/openshift.yaml
@@ -29,8 +29,8 @@ users:
   - system:serviceaccount:{{ .Release.Namespace }}
   - system:serviceaccount:{{ .Release.Namespace }}:{{ include "sentinelone.serviceAccountName" . }}
 volumes:
+  - configMap
   - hostPath
   - secret
-  - configMap
 {{- end }}
 


### PR DESCRIPTION
changed in order to solve a sync problem with gitops tools