### PR TITLE
Mount containerd.sock for gk3 as well

### DIFF
--- a/charts/s1-agent/templates/agent/daemonset.yaml
+++ b/charts/s1-agent/templates/agent/daemonset.yaml
@@ -97,9 +97,6 @@ spec:
           - name: persistence
             mountPath: {{ include "persistentDir" . }}
 {{- else }}
-          - name: containerd
-            mountPath: /run/containerd/containerd.sock
-            readOnly: true
           - name: crio
             mountPath: /run/crio/crio.sock
             readOnly: true
@@ -107,6 +104,9 @@ spec:
             mountPath: /var/run/cri-dockerd.sock
             readOnly: true
 {{- end }}
+          - name: containerd
+            mountPath: /run/containerd/containerd.sock
+            readOnly: true
           - name: config
             mountPath: /opt/configmaps/config
             readOnly: true
@@ -136,9 +136,6 @@ spec:
           hostPath:
             path: {{ include "persistentDir" . }}
 {{- else }}
-        - name: containerd
-          hostPath:
-            path: /run/containerd/containerd.sock
         - name: crio
           hostPath:
             path: /run/crio/crio.sock
@@ -146,6 +143,9 @@ spec:
           hostPath:
             path: /var/run/cri-dockerd.sock
 {{- end }}
+        - name: containerd
+          hostPath:
+            path: /run/containerd/containerd.sock
         - name: config
           configMap:
             name: {{ include "agent.fullname" . }}-config


### PR DESCRIPTION
Before the change we failed loading grpc cause there was no proper docker group in the container
```
gk3-autopilot-cluster-4-pool-1-5c9c3cef-g7ip:/# grep "set_process_permissions" /opt/sentinelone/log/*.log
/opt/sentinelone/log/network.log:[2025-03-06 11:35:04.061382] [3287389] [warning] set_process_permissions failed with: group name = docker
```

Now there's no such warning anymore, and image ids seem to be brought, for example:
```
/opt/sentinelone/log/network.log:[2025-03-06 11:13:25.420083] [3434545] [debug] Helper client: image name gke.gcr.io/gke-metrics-collector:20250129_2300_RC0@sha256:360c05bb437d77b55090ba512bddfda52f62166c78171593d1152327db2a914f id e50858e31f48523c684077e24f27aaeff05ece8b533310f083179c1056edf731
```