### PR TITLE
Add support for a tag suffix in values

### DIFF
--- a/charts/s1-agent/templates/_helpers.tpl
+++ b/charts/s1-agent/templates/_helpers.tpl
@@ -262,7 +262,7 @@ Generate server token for helper secret
 {{- if .Values.configuration.image.helper -}}
 {{ .Values.configuration.image.helper }}
 {{- else -}}
-{{ required "Must set the appropriate registry for agent helper pulling" .Values.configuration.repositories.helper }}:{{ default .Values.configuration.tag.agent .Values.configuration.tag.helper }}
+{{ required "Must set the appropriate registry for agent helper pulling" .Values.configuration.repositories.helper }}:{{ default .Values.configuration.tag.agent .Values.configuration.tag.helper }}{{ .Values.configuration.tag_suffix.helper }}
 {{- end -}}
 {{- end -}}
 
@@ -270,7 +270,7 @@ Generate server token for helper secret
 {{- if .Values.configuration.image.agent -}}
 {{ .Values.configuration.image.agent }}
 {{- else -}}
-{{ required "Must set the appropriate registry for agent image pulling" .Values.configuration.repositories.agent }}:{{ required "Must set the appropriate tag for agent image pulling" .Values.configuration.tag.agent }}
+{{ required "Must set the appropriate registry for agent image pulling" .Values.configuration.repositories.agent }}:{{ required "Must set the appropriate tag for agent image pulling" .Values.configuration.tag.agent }}{{ .Values.configuration.tag_suffix.agent }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/s1-agent/values.yaml
+++ b/charts/s1-agent/values.yaml
@@ -20,6 +20,9 @@ configuration:
   tag:
     agent: "25.3.1" # IF you want to use a different tag for the agent (only do so if advised by support), please replace this with the relevant tag for the agent image
     helper: "25.3.1" # IF you want to use a different tag for the helper (only do so if advised by support), please replace this with the relevant tag for the helper image
+  tag_suffix:
+    agent: ""
+    helper: ""
   proxy: "" # specify a proxy server (in URL format), if needed
   dv_proxy: "" # specify a proxy server for Deep-Visibility (in URL format), if needed
   env:


### PR DESCRIPTION
TLDR: This pr adds a additional values field, to provide a suffix for the tag, like -ga, -ea, ... This helps when replicating the images from the s1 registry.


When directly replicating the images from containers.sentinelone.net, images get suffixed with their release state (ga/ea). This resulst in the need to adjust the tag values for each upgrade. With this pr you can just provide -ga/-ea as suffix for you tag and simply update the helm chart, 