### PR TITLE
Ensure with pre-install hook the Secret is not overwritten

### DIFF
--- a/charts/s1-agent/templates/common/secrets.yaml
+++ b/charts/s1-agent/templates/common/secrets.yaml
@@ -23,6 +23,7 @@ metadata:
   labels: {{- include "sentinelone.helper.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 type: kubernetes.io/tls
 data: {{- include "helper.certificates" . | nindent 2 }}
 {{- end }}

--- a/charts/s1-agent/templates/common/secrets.yaml
+++ b/charts/s1-agent/templates/common/secrets.yaml
@@ -21,6 +21,8 @@ kind: Secret
 metadata:
   name: {{ include "helper.secret.name" . }}
   labels: {{- include "sentinelone.helper.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install
 type: kubernetes.io/tls
 data: {{- include "helper.certificates" . | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
Running IaC may cause issues with the helper-secret filled by the helper-pod with certificates.
Adding the pre-install hook will mitigate this issue. Please check my links for explanation 



ref: 
- https://github.com/helm/helm-www/issues/1259
- https://github.com/spoud/kafka-cost-control/pull/428