### PR TITLE
[CLS-67027] Support Installing the agent on Openshift using Argocd

### DIFF
--- a/charts/s1-agent/templates/_helpers.tpl
+++ b/charts/s1-agent/templates/_helpers.tpl
@@ -305,14 +305,20 @@ certificates:
   value: "{{ .Values.configuration.custom_ca }}"
 - name: S1_HELPER_PORT
   value: "{{ include "service.port" . }}"
+{{- if .Values.configuration.proxy }}
 - name: S1_MANAGEMENT_PROXY
   value: "{{ default "" .Values.configuration.proxy }}"
+{{- end }}
+{{- if .Values.configuration.dv_proxy }}
 - name: S1_DV_PROXY
   value: "{{ default "" .Values.configuration.dv_proxy }}"
+{{- end }}
 - name: S1_HEAP_TRIMMING_ENABLE
-  value: "{{ .Values.configuration.env.agent.heap_trimming_enable }}"
+  value: "{{ default "true" .Values.configuration.env.agent.heap_trimming_enable }}"
+{{- if .Values.configuration.env.agent.heap_trimming_interval }}
 - name: S1_HEAP_TRIMMING_INTERVAL
   value: "{{ .Values.configuration.env.agent.heap_trimming_interval }}"
+{{- end }}
 - name: S1_LOG_LEVEL
   value: "{{ .Values.configuration.env.agent.log_level }}"
 - name: S1_WATCHDOG_HEALTHCHECK_TIMEOUT
@@ -322,9 +328,9 @@ certificates:
 - name: S1_HELPER_HEALTHCHECK_INTERVAL
   value: "{{ .Values.configuration.env.agent.helper_healthcheck_interval }}"
 - name: S1_FIPS_ENABLED
-  value: "{{ .Values.configuration.env.agent.fips_enabled }}"
+  value: "{{ default "false" .Values.configuration.env.agent.fips_enabled }}"
 - name: S1_AGENT_ENABLED
-  value: "{{ .Values.configuration.env.agent.enabled }}"
+  value: "{{ default "true" .Values.configuration.env.agent.enabled }}"
 - name: S1_POD_NAME
   valueFrom:
     fieldRef:

--- a/charts/s1-agent/templates/agent/daemonset.yaml
+++ b/charts/s1-agent/templates/agent/daemonset.yaml
@@ -25,7 +25,10 @@ spec:
       {{- if .Values.agent.podAnnotations }}
 {{ toYaml .Values.agent.podAnnotations | indent 8 }}
       {{- end }}
-      {{- if semverCompare "<1.30.0" (printf "%d.%d.0" (semver .Capabilities.KubeVersion.Version).Major (semver .Capabilities.KubeVersion.Version).Minor) }}
+      {{- if and
+          (semverCompare "<1.30.0" (printf "%d.%d.0" (semver .Capabilities.KubeVersion.Version).Major (semver .Capabilities.KubeVersion.Version).Minor))
+          (not (eq .Values.configuration.platform.type "openshift"))
+      }}
       {{ default "container.apparmor.security.beta.kubernetes.io/s1-agent" .Values.agent.apparmorAnnotation }}: {{ default "unconfined" (lower .Values.agent.apparmorPolicy) }}
       {{- end }}
     spec:
@@ -39,7 +42,10 @@ spec:
       securityContext:
         runAsUser: {{ .Values.configuration.env.agent.pod_uid }}
         runAsGroup: {{ .Values.configuration.env.agent.pod_gid }}
-        {{- if semverCompare ">=1.30.0" (printf "%d.%d.0" (semver .Capabilities.KubeVersion.Version).Major (semver .Capabilities.KubeVersion.Version).Minor) }}
+        {{- if and
+          (semverCompare ">=1.30.0" (printf "%d.%d.0" (semver .Capabilities.KubeVersion.Version).Major (semver .Capabilities.KubeVersion.Version).Minor))
+          (not (eq .Values.configuration.platform.type "openshift"))
+        }}
         appArmorProfile:
           type: {{ default "Unconfined" .Values.agent.apparmorPolicy }}
           {{- if eq .Values.agent.apparmorPolicy "Localhost" }}
@@ -82,7 +88,7 @@ spec:
         - name: S1_AGENT_CONFIG_PATH
           value: "/opt/configmaps/config"
         - name: S1_EBPF_ENABLED
-          value: "{{ .Values.configuration.env.agent.ebpf_enabled }}"
+          value: "{{ default "true" .Values.configuration.env.agent.ebpf_enabled }}"
 {{- if .Values.configuration.platform.gke.autopilot }}
         - name: S1_GKE_AUTOPILOT
           value: "true"

--- a/charts/s1-agent/templates/hooks/argocd-post-delete-hook.yaml
+++ b/charts/s1-agent/templates/hooks/argocd-post-delete-hook.yaml
@@ -25,6 +25,8 @@ spec:
       serviceAccountName: {{ include "sentinelone.serviceAccountName" . }}
       containers:
         - name: {{ include "argocdPostDeleteHook.name" . }}
+          securityContext:
+            {{- toYaml .Values.helper.securityContext | nindent 12 }}
           image: "{{ include "helper.full_url" . }}"
           command: [ "/bin/bash", "-c" ]
           args:

--- a/charts/s1-agent/templates/hooks/pre-delete-hook.yaml
+++ b/charts/s1-agent/templates/hooks/pre-delete-hook.yaml
@@ -26,6 +26,8 @@ spec:
       containers:
         - name: {{ include "preDeleteHook.name" . }}
           image: "{{ include "helper.full_url" . }}"
+          securityContext:
+            {{- toYaml .Values.helper.securityContext | nindent 12 }}
           resources:
             requests:
               cpu: 250m

--- a/charts/s1-agent/templates/platforms/openshift/openshift.yaml
+++ b/charts/s1-agent/templates/platforms/openshift/openshift.yaml
@@ -5,6 +5,10 @@ metadata:
   name: s1 
   labels:
     {{- include "sentinelone.helper.labels" . | nindent 4 }}
+  {{ if eq (include "argocdPostDeleteHook.enabled" .) "true" }}
+  annotations:
+    argocd.argoproj.io/sync-options: Delete=false
+  {{- end }}
 allowPrivilegedContainer: false
 allowHostDirVolumePlugin: true
 allowHostIPC: false


### PR DESCRIPTION
In openshift due to security policies, these are not passed anyways to generated yaml.

Also, don't pass the apparmor annotation as apparmor is anyway not supported in openshift and therefore not passed.

This fixes some current issues causing `outofsync` for s1 apps installed on openshifts via argocd.


Master:
https://jpaas.s1.guru/job/automation/job/cws/job/automation-runner/22407/

This branch:
https://jpaas.s1.guru/job/automation/job/cws/job/automation-runner/22408/

EKS Offline:
https://jpaas.s1.guru/job/automation/job/cws/job/automation-runner/22412/