### PR TITLE
templates: _helpers: Remove use of sudo in agent's container

### DIFF
--- a/charts/s1-agent/templates/_helpers.tpl
+++ b/charts/s1-agent/templates/_helpers.tpl
@@ -534,7 +534,7 @@ for i in {1..2}; do
     xargs -P 0 -I % bash -c '
       out=$(for i in {1..3}; do
               timeout 30 /s1-helper/kubectl exec % -- bash -c "
-                    sudo test -f /opt/sentinelone/tmp/uninstall_started && echo Already uninstalled || sudo sentinelctl control uninstall
+                    sentinelctl control uninstall
                 " && exit 0 || sleep 2;
             done;
             exit 1


### PR DESCRIPTION
Remove usage of sudo in agent's container from pre_delete hook
Part of the following [agent PR](https://ghe.eng.sentinelone.tech/sentinel-one/linuxagent_ng/pull/4803) 

- sentinelctl runs without sudo
- Test -f is not needed, since there is a check in  sentinelctl in `handle_uninstall_offline` function if this file exists, and if it does it returns immediately from uninstall