### PR TITLE
Add pod subresources to validating

### DIFF
--- a/charts/s1-agent/values.yaml
+++ b/charts/s1-agent/values.yaml
@@ -140,6 +140,7 @@ admissionControllers:
       - CONNECT
       resources:
       - '*'
+      - 'pods/*'
       scope: '*'
     matchConditions:
       - name: 'exclude-leases'


### PR DESCRIPTION
We want to send connect events to pods for review in our dynamic admission controller.

Marking all resources with '*' does not send sub-resources such as PodExecOptions for review so we need to add all the pod sub-resources.