### PR TITLE
feat(chart): Ensure helper secret stability across upgrades

### DIFF
--- a/charts/s1-agent/templates/common/secrets.yaml
+++ b/charts/s1-agent/templates/common/secrets.yaml
@@ -16,24 +16,42 @@ data:
 ---
 
 {{- if and (include "helper.secret.create" .) (eq (include "webhooks.enabled" .) "false") }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace (include "helper.secret.name" .) }}
+{{- $secretData := "" }}
+{{- if and $existingSecret $existingSecret.data }}
+{{- $secretData = $existingSecret.data | toYaml }}
+{{- else }}
+{{- $secretData = include "helper.certificates" . }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "helper.secret.name" . }}
   labels: {{- include "sentinelone.helper.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/resource-policy": keep
 type: kubernetes.io/tls
-data: {{- include "helper.certificates" . | nindent 2 }}
+data: {{- $secretData | nindent 2 }}
 {{- end }}
 
 ---
 
 {{- if include "helper_token.secret.create" . }}
+{{- $existingToken := lookup "v1" "Secret" .Release.Namespace (include "helper_token.secret.name" .) }}
+{{- $serverToken := "" }}
+{{- if and $existingToken $existingToken.data (index $existingToken.data "server-token") }}
+{{- $serverToken = index $existingToken.data "server-token" | quote }}
+{{- else }}
+{{- $serverToken = include "helper.token" . }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "helper_token.secret.name" . }}
   labels: {{- include "sentinelone.helper.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/resource-policy": keep
 type: Opaque
 data:
-  server-token: {{ include "helper.token" . }}
+  server-token: {{ $serverToken }}
 {{- end -}}

--- a/charts/s1-agent/templates/hooks/webhookconfiguration.yaml
+++ b/charts/s1-agent/templates/hooks/webhookconfiguration.yaml
@@ -1,13 +1,18 @@
 {{ if eq (include "webhooks.enabled" .) "true" }}
 {{- $certs := "" }}
 {{- $caBundle := "" }}
+{{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (include "helper.secret.name" .)) }}
 {{- if include "helper.secret.create" . }}
+{{- if and $existingSecret $existingSecret.data }}
+{{- $certs = $existingSecret.data | toYaml -}}
+{{- $caBundle = index $existingSecret.data "ca.crt" -}}
+{{- else }}
 {{- $certs = include "helper.certificates" . -}}
 {{- $caBundle = index ($certs | fromYaml) "ca.crt" -}}
+{{- end }}
 {{- else }}
-{{- $secret := (lookup "v1" "Secret" .Release.Namespace (include "helper.secret.name" .)) }}
-{{- if $secret -}}
-{{- $caBundle = index $secret "data" "ca.crt" -}}
+{{- if $existingSecret -}}
+{{- $caBundle = index $existingSecret "data" "ca.crt" -}}
 {{- end }}
 {{- end }}
 
@@ -19,6 +24,8 @@ kind: Secret
 metadata:
   name: {{ include "helper.secret.name" . }}
   labels: {{- include "sentinelone.helper.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/resource-policy": keep
 type: kubernetes.io/tls
 data: {{- $certs | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
### Description

This PR addresses an idempotency issue where the helper's TLS certificate (`sentinelone-helper`) and server-token (`sentinelone-helper-token`) secrets were regenerated on every `helm upgrade`, Flux reconciliation, or `terraform apply`.

### Problem

Constant rotation of these secrets causes several operational issues:
- **Service Disruption:** Regenerating the TLS certificate can interrupt communication between agents and the helper service.
- **GitOps Issue:** It creates unnecessary noise in GitOps diffs (e.g., in ArgoCD or Flux), making it difficult to identify meaningful changes.
- **Unpredictable State:** The cluster's state changes with every reconciliation, even when no configuration values have been modified.

### Solution

This change introduces the use of the Helm `lookup()` function to check if the helper secrets already exist in the cluster before rendering them.

- **On first installation:** The secrets are generated and created as before.
- **On subsequent upgrades/reconciliations:** If the secrets are found, their existing data is reused, preventing rotation.

The `helm.sh/resource-policy: keep` annotation remains on the secrets to prevent accidental deletion during a `helm uninstall`, preserving their state for future installations if desired.

### ArgoCD Considerations

Due to the timing of how ArgoCD renders templates, `lookup()` may not find the secret during the sync planning phase and will attempt to regenerate it. The recommended workaround for ArgoCD users is to add `ignoreDifferences` rules for the `/data` field on both secrets within the `Application` resource specification.

**Example ArgoCD `ignoreDifferences`:**
```yaml
spec:
  # ...
  ignoreDifferences:
  - group: ""
    kind: Secret
    name: sentinelone-helper
    jsonPointers:
    - /data
  - group: ""
    kind: Secret
    name: sentinelone-helper-token
    jsonPointers:
    - /data