### PR TITLE
[CLS-79148] reduce helper healthcheck retries and remove heap trimming configuration

### DIFF
--- a/charts/s1-agent/templates/_helpers.tpl
+++ b/charts/s1-agent/templates/_helpers.tpl
@@ -346,14 +346,6 @@ certificates:
 - name: S1_DV_PROXY
   value: "{{ default "" .Values.configuration.dv_proxy }}"
 {{- end }}
-{{- if kindIs "bool" .Values.configuration.env.agent.heap_trimming_enable }}
-- name: S1_HEAP_TRIMMING_ENABLE
-  value: "{{ .Values.configuration.env.agent.heap_trimming_enable }}"
-{{- end }}
-{{- if .Values.configuration.env.agent.heap_trimming_interval }}
-- name: S1_HEAP_TRIMMING_INTERVAL
-  value: "{{ .Values.configuration.env.agent.heap_trimming_interval }}"
-{{- end }}
 {{- if .Values.configuration.env.agent.log_level }}
 - name: S1_LOG_LEVEL
   value: "{{ .Values.configuration.env.agent.log_level }}"

--- a/charts/s1-agent/values.yaml
+++ b/charts/s1-agent/values.yaml
@@ -36,8 +36,6 @@ configuration:
       host_mount_path: # leave default unless host path is mounted elsewhere in your environment
       persistent_dir: # path on the node to a directory that will be used for persistent storage (logs, configuration, etc. Unsupported in GKE autopilot)
       persistent_dir_removal_upon_installation: false # removes an existing persistent dir upon installation if uninstall hook failed in last uninstall operation (Unsupported with GitOps deployments)
-      heap_trimming_enable: # to enable/disable heap trimming, set to 'true'/'false'
-      heap_trimming_interval: # heap trimming default interval (s)
       log_level: "" # info, error, warning, debug, trace (defaults to 'info')
       pod_uid: 1000 # uid of the default pod user
       pod_gid: 1000 # gid of the default pod group


### PR DESCRIPTION
This PR comes to reduce the number of retries the agent performs when trying to connect to the helper on startup, this is due to it being too long and now with addition of startup probes it probe has lower timeout than the time all the retries take so it resets the agent pod if it cant connect to the helper.

Also we remove configuration support for heap trimming, the feature will be enabled by default in the agent.