### PR TITLE
[CLS-82861] charts: support exp-backoff healthcheck

### DIFF
--- a/charts/s1-agent/values.yaml
+++ b/charts/s1-agent/values.yaml
@@ -42,8 +42,7 @@ configuration:
       pod_uid: 1000 # uid of the default pod user
       pod_gid: 1000 # gid of the default pod group
       watchdog_healthcheck_timeout: 15 # watchdog healthcheck timeout before exiting the pod entrypoint. (seconds, 0=disabled)
-      helper_healthcheck_retry: 20 # amount of tries to verify the helper service is running before starting the agent.
-      helper_healthcheck_interval: 5 # time to wait between each try. (seconds)
+      helper_healthcheck_retry: 15 # amount of tries to verify the helper service is running before starting the agent.
       fips_enabled: # to enable/disable FIPS mode, set to 'true'/'false'
       ebpf_enabled: # to disable EBPF mode, set to 'false' (Unsupported in EKS Fargate)
       container_runtime_endpoint: "" # leave empty for default, or specify without 'unix://' domain, e.g. "/run/containerd/containerd.sock"


### PR DESCRIPTION
## Changes made
Switch to exponential backoff for helper readiness
Drop `helper_healthcheck_interval` — the agent now uses a capped exponential backoff (1s → 2s → 4s → 8s, capped) instead of a fixed sleep.
Default `helper_healthcheck_retry`: 20 → 15 — the new schedule is denser up front and capped at the tail, so 15 attempts cover the same wall-clock budget and still fit inside the pod startupProbe window.