### PR TITLE
[CLS-83407] Support configurable replicas for the helper

### DIFF
--- a/charts/s1-agent/templates/_helpers.tpl
+++ b/charts/s1-agent/templates/_helpers.tpl
@@ -230,7 +230,14 @@ Create the name of the service account to use
 Generate certificates for helper secret
 */}}
 {{- define "helper.certificates" -}}
-{{- $altNames := list ( printf "%s" "localhost" ) ( printf "%s" (include "helper.fullname" .) ) ( printf "%s.%s" (include "helper.fullname" .) .Release.Namespace ) ( printf "%s.%s.svc" (include "helper.fullname" .) .Release.Namespace ) -}}
+{{- $altNames := list
+    ( printf "%s" "localhost" )
+    ( printf "%s" (include "helper.fullname" .) )
+    ( printf "%s.%s" (include "helper.fullname" .) .Release.Namespace )
+    ( printf "%s.%s.svc" (include "helper.fullname" .) .Release.Namespace )
+    ( printf "%s" (include "service.admission.name" .) )
+    ( printf "%s.%s" (include "service.admission.name" .) .Release.Namespace )
+    ( printf "%s.%s.svc" (include "service.admission.name" .) .Release.Namespace ) -}}
 {{- $ca := genCA ( printf "%s ca" .Release.Namespace ) (int .Values.secrets.helper_certificate_expiration_duration) -}}
 {{- $caCert := $ca.Cert | b64enc -}}
 {{- $cert := genSignedCert ( include "helper.secret.name" . ) nil $altNames (int .Values.secrets.helper_certificate_expiration_duration) $ca -}}
@@ -260,6 +267,16 @@ Generate server token for helper secret
 
 {{- define "service.name" -}}
 {{- include "helper.fullname" . -}}
+{{- end -}}
+
+{{/*
+Name of the admission-only service that routes exclusively to helper pod-0.
+Used by ValidatingWebhookConfiguration (and MutatingWebhookConfiguration when
+agent injection is enabled) to ensure admission-controller requests always land
+on the primary replica.
+*/}}
+{{- define "service.admission.name" -}}
+{{- printf "%s-%s" (include "helper.fullname" .) "primary" -}}
 {{- end -}}
 
 {{- define "service.port" -}}

--- a/charts/s1-agent/templates/helper/service.yaml
+++ b/charts/s1-agent/templates/helper/service.yaml
@@ -16,3 +16,27 @@ spec:
       name: https
   selector:
         {{- include "sentinelone.helper.selector.labels" . | nindent 4 }}
+---
+# Primary service — routes exclusively to helper pod-0 (the admission-controller
+# primary). Kubernetes automatically labels every StatefulSet pod with
+# statefulset.kubernetes.io/pod-name=<sts-name>-<ordinal>, so adding that label
+# to this selector is enough to pin traffic to the first replica.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "service.admission.name" . }}
+  labels: {{- include "sentinelone.helper.labels" . | nindent 4 }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ include "service.port" . }}
+      targetPort: {{ include "service.target_port" . }}
+      protocol: TCP
+      name: https
+  selector:
+        {{- include "sentinelone.helper.selector.labels" . | nindent 4 }}
+    statefulset.kubernetes.io/pod-name: {{ include "helper.fullname" . }}-0

--- a/charts/s1-agent/templates/helper/statefulset.yaml
+++ b/charts/s1-agent/templates/helper/statefulset.yaml
@@ -9,7 +9,7 @@ metadata:
     argocd.argoproj.io/sync-options: Delete=false
     {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.helper.replicas }}
   serviceName: {{ include "service.name" . }}
   selector:
     matchLabels:

--- a/charts/s1-agent/templates/hooks/webhookconfiguration.yaml
+++ b/charts/s1-agent/templates/hooks/webhookconfiguration.yaml
@@ -40,7 +40,7 @@ webhooks:
   clientConfig:
     caBundle: {{ $caBundle }}
     service:
-      name: {{ include "service.name" . }}
+      name: {{ include "service.admission.name" . }}
       namespace: {{ .Release.Namespace }}
       path: /agent/inject
       port: {{ include "service.port" . }}
@@ -77,7 +77,7 @@ webhooks:
   clientConfig:
     caBundle: {{ $caBundle }}
     service:
-      name: {{ include "service.name" . }}
+      name: {{ include "service.admission.name" . }}
       namespace: {{ .Release.Namespace }}
       path: /admissioncontrollers/validate
       port: {{ include "service.port" . }}

--- a/charts/s1-agent/values.yaml
+++ b/charts/s1-agent/values.yaml
@@ -147,6 +147,7 @@ admissionControllers:
         expression: '!(request.resource.group == "coordination.k8s.io" && request.resource.resource == "leases")' # Match non-lease resources.
 
 helper:
+  replicas: 1 # Number of helper replicas. Admission controller validation requests are always routed to pod-0.
   fullnameOverride: ""
   nameOverride: ""
   labels: {}


### PR DESCRIPTION
In addition create a new helper service with just the first helper instance so it will be used for the admission controller