### PR TITLE
[CLS-83939] charts: inject custom CA cert into Fargate injected agent

### DIFF
--- a/charts/s1-agent/templates/_helpers.tpl
+++ b/charts/s1-agent/templates/_helpers.tpl
@@ -625,6 +625,9 @@ requests:
 {{- if .Values.configuration.env.injection.enabled -}}
 {{- $_ := set $helperConfig "S1_NAMESPACE_INJECTION_SELECTORS" (default "" (toJson .Values.agentInjection.selector.namespaceSelector.matchLabels)) -}}
 {{- $_ := set $helperConfig "S1_INJECTION_CREATE_SITE_TOKEN_SECRET" (include "site_key.secret.create" .) -}}
+{{- if include "custom_ca.secret.create" . -}}
+{{- $_ := set $helperConfig "S1_CUSTOM_CA_SECRET_NAME" (include "custom_ca.secret.name" .) -}}
+{{- end -}}
 {{- end -}}
 {{- $_ := set $helperConfig "S1_NDR_ENABLED" (printf "%t" .Values.configuration.env.helper.ndr_enabled) -}}
 {{- $_ := set $helperConfig "S1_VALIDATING_ADMISSION_CONTROLLER_ENABLED" (printf "%t" .Values.configuration.env.admission_controllers.validating.enabled) -}}

--- a/charts/s1-agent/templates/common/configmaps.yaml
+++ b/charts/s1-agent/templates/common/configmaps.yaml
@@ -25,10 +25,20 @@ data:
           volumeMounts:
           - name: {{ include "agent.fullname" . }}
             mountPath: /{{ include "agent.fullname" . }}
+{{- if .Values.configuration.custom_ca }}
+          - name: ca-certs
+            mountPath: "/usr/local/share/ca-certificates"
+            readOnly: true
+{{- end }}
       volumes:
       - name: {{ include "agent.fullname" . }}
         configMap:
           name: {{ include "agent.fullname" . }}
+{{- if .Values.configuration.custom_ca }}
+      - name: ca-certs
+        secret:
+          secretName: {{ include "custom_ca.secret.name" . }}
+{{- end }}
 {{ end }}
 
 ---


### PR DESCRIPTION
## Summary
- Mount the custom CA secret as a volume in the injection ConfigMap so injected agents on EKS Fargate can trust a private console CA
- Add `S1_CUSTOM_CA_SECRET_NAME` env var to the helper statefulset (only when the chart creates the secret, not when the customer provides one via `custom_ca_name`) so the helper can propagate the secret to target namespaces synchronously during webhook injection

## Test plan
- [x] Deploy with `configuration.custom_ca=true` + a PEM file on EKS Fargate; verify injected agent pod mounts `ca-certs` volume and reaches Running state
- [x] Verify `S1_CUSTOM_CA_SECRET_NAME` env var is present on helper pod when chart creates the secret
- [x] Deploy with `configuration.custom_ca_name=my-existing-ca`; verify `S1_CUSTOM_CA_SECRET_NAME` is NOT set on helper pod (customer-managed secret case)
- [x] Deploy with `configuration.custom_ca=false`; verify no `ca-certs` volume or mount appears anywhere