### PR TITLE
[CLS-84749] charts: s1-agent: add fargate_ptrace_allow injection toggle

### DIFF
--- a/charts/s1-agent/templates/_helpers.tpl
+++ b/charts/s1-agent/templates/_helpers.tpl
@@ -556,6 +556,10 @@ procMount: Default
     value: "0"
   - name: S1_POD_GID
     value: "0"
+{{- if .Values.configuration.env.injection.fargate_ptrace_allow }}
+  - name: LD_PRELOAD
+    value: "/usr/local/lib/libptrace_allow.so"
+{{- end }}
 {{- end -}}
 
 {{- define "helper.rbac.annotations" -}}
@@ -625,6 +629,7 @@ requests:
 {{- if .Values.configuration.env.injection.enabled -}}
 {{- $_ := set $helperConfig "S1_NAMESPACE_INJECTION_SELECTORS" (default "" (toJson .Values.agentInjection.selector.namespaceSelector.matchLabels)) -}}
 {{- $_ := set $helperConfig "S1_INJECTION_CREATE_SITE_TOKEN_SECRET" (include "site_key.secret.create" .) -}}
+{{- $_ := set $helperConfig "S1_FARGATE_PTRACE_ALLOW" (printf "%t" .Values.configuration.env.injection.fargate_ptrace_allow) -}}
 {{- if include "custom_ca.secret.create" . -}}
 {{- $_ := set $helperConfig "S1_CUSTOM_CA_SECRET_NAME" (include "custom_ca.secret.name" .) -}}
 {{- end -}}

--- a/charts/s1-agent/templates/_helpers.tpl
+++ b/charts/s1-agent/templates/_helpers.tpl
@@ -559,6 +559,8 @@ procMount: Default
 {{- if .Values.configuration.env.injection.fargate_ptrace_allow }}
   - name: LD_PRELOAD
     value: "/usr/local/lib/libptrace_allow.so"
+  - name: S1_FARGATE_PTRACE_ALLOW
+    value: "true"
 {{- end }}
 {{- end -}}
 

--- a/charts/s1-agent/templates/helper/statefulset.yaml
+++ b/charts/s1-agent/templates/helper/statefulset.yaml
@@ -121,6 +121,10 @@ spec:
 {{- end }}
           - name: AGENT_CONTAINER_NAME
             value: "{{ include "agent.container_name" . }}"
+{{- if and .Values.configuration.env.injection.enabled .Values.configuration.env.injection.fargate_ptrace_allow }}
+          - name: LD_PRELOAD
+            value: "/s1-helper/bin/libptrace_allow.so"
+{{- end }}
           ports:
             - name: https
               containerPort: {{ include "service.target_port" . }}

--- a/charts/s1-agent/values.yaml
+++ b/charts/s1-agent/values.yaml
@@ -61,6 +61,7 @@ configuration:
       hostNetwork: false # set to 'true' in case you are running on EKS with amazon linux 2023 ami and hop limit for the instance metadata of 1 in order for the helper to fetch instance metadata
     injection:
       enabled: false # to enable agent injection mode on AWS Fargate, set to 'true'
+      fargate_ptrace_allow: true # inject s1-fargate-init + libptrace_allow.so into Fargate pods so the agent can ptrace workload processes; set to 'false' to skip the CMD wrap + LD_PRELOAD injection
     admission_controllers:
       validating:
         enabled: false # to enable validating admission controller, set to 'true'


### PR DESCRIPTION
## Summary

Adds `configuration.env.injection.fargate_ptrace_allow` (default `true`) — a toggle to control whether the agent injects ptrace-allow support into Fargate pods during webhook injection. Set to `false` to skip the injection for environments where it is not needed.