### PR TITLE
[CLS-83402] charts: add pod namespace/label filter config for helper

### DIFF
--- a/charts/s1-agent/templates/_helpers.tpl
+++ b/charts/s1-agent/templates/_helpers.tpl
@@ -636,6 +636,12 @@ requests:
 {{- $_ := set $helperConfig "S1_USE_CUSTOM_CA" (printf "%t" .Values.configuration.custom_ca) -}}
 {{- $_ := set $helperConfig "S1_EXCLUDE_NON_RUNNING_CONTAINERS" (printf "%t" .Values.configuration.env.helper.exclude_non_running_containers) -}}
 {{- $_ := set $helperConfig "S1_EXCLUDE_INIT_CONTAINERS" (printf "%t" .Values.configuration.env.helper.exclude_init_containers) -}}
+{{- if .Values.configuration.env.helper.pod_filter.namespaces -}}
+{{- $_ := set $helperConfig "S1_POD_FILTER_NAMESPACES" (join "," .Values.configuration.env.helper.pod_filter.namespaces) -}}
+{{- end -}}
+{{- if .Values.configuration.env.helper.pod_filter.label_selectors -}}
+{{- $_ := set $helperConfig "S1_POD_FILTER_LABEL_SELECTORS" (join "|" .Values.configuration.env.helper.pod_filter.label_selectors) -}}
+{{- end -}}
 {{- $helperConfig | toYaml -}}
 {{- end -}}
 

--- a/charts/s1-agent/values.yaml
+++ b/charts/s1-agent/values.yaml
@@ -55,6 +55,17 @@ configuration:
       ndr_enabled: false # to enable ndr mode, set to 'true' (Unsupported)
       exclude_non_running_containers: true # to enable non-running containers metadata discovery, set to 'false'
       exclude_init_containers: false # to exclude init containers metadata discovery, set to 'true'
+      pod_filter:
+        # Optional: restrict the pods informer to specific namespaces (OR logic).
+        # Leave empty to watch all namespaces (default behaviour).
+        # Example: ["default", "production"]
+        namespaces: []
+        # Optional: restrict the pods informer to pods matching these label selectors (OR logic).
+        # Each list entry is a standard Kubernetes label selector string where commas mean AND
+        # within that entry (e.g. "app=frontend,env=prod"). Multiple entries are OR-ed together.
+        # Leave empty for no label filtering (default behaviour).
+        # Example: ["app=myapp", "tier=backend,env=prod"]
+        label_selectors: []
       ports:
         grpc: 5071 # gRPC server control port
         target: 6443 # Server target port (HTTPS)


### PR DESCRIPTION
Add pod_filter.namespaces and pod_filter.label_selectors to configuration.env.helper in values.yaml. Map them to env vars S1_POD_FILTER_NAMESPACES (comma-joined) and S1_POD_FILTER_LABEL_SELECTORS (pipe-joined) in the helper ConfigMap template.