### PR TITLE
s1-agent: wrap helper CMD with s1-fargate-init only on serverless far…

### DIFF
--- a/charts/s1-agent/templates/helper/statefulset.yaml
+++ b/charts/s1-agent/templates/helper/statefulset.yaml
@@ -59,6 +59,16 @@ spec:
             {{- include "helperContainerSecurityContext" . | nindent 12 }}
           image: "{{ include "helper.full_url" . }}"
           imagePullPolicy: {{ default "IfNotPresent" .Values.configuration.imagePullPolicy }}
+{{- if and (eq (include "serverlessOnlyMode" .) "true") .Values.configuration.env.injection.enabled .Values.configuration.env.injection.fargate_ptrace_allow }}
+          # Wrap the image CMD with s1-fargate-init so it relaxes the Yama ptrace
+          # scope (prctl PR_SET_PTRACER) before exec'ing the helper app. Only in
+          # serverlessOnlyMode does the helper run on a Fargate node with the agent
+          # sidecar sharing its PID namespace, so only then must it be ptrace-able.
+          # LD_PRELOAD below covers dynamic children, this covers the
+          # statically-linked entrypoint. Keep this argv in sync with the image
+          # CMD in helper/build/Dockerfile.
+          command: ["/s1-helper/bin/s1-fargate-init", "/bin/sh", "-c", "(rm -f ./kubectl.tar.gz || true) && exec s1-helper-app"]
+{{- end }}
           envFrom:
           - configMapRef:
               name: {{ include "helper.config.name" .}}


### PR DESCRIPTION
…gate

The helper image no longer bakes s1-fargate-init into its CMD (it runs s1-helper-app directly), so the Yama ptrace scope is no longer relaxed on every cluster. Override the helper container command to prepend s1-fargate-init only when all of:
  - serverlessOnlyMode is true -- only then does the helper run on a Fargate node with the agent sidecar sharing its PID namespace, so only then must the helper be ptrace-able;
  - injection is enabled and injection.fargate_ptrace_allow is set -- the same guard already used for the helper's LD_PRELOAD.

LD_PRELOAD covers dynamically-linked children; this wrap covers the statically-linked helper entrypoint that LD_PRELOAD cannot reach. On any other cluster the command is left unset, so the image CMD runs and the ptrace scope is untouched.